### PR TITLE
Add label size options and label content features

### DIFF
--- a/app/(dashboard)/items/[itemId]/print/PrintPageClient.tsx
+++ b/app/(dashboard)/items/[itemId]/print/PrintPageClient.tsx
@@ -1,21 +1,115 @@
 "use client";
 
+import { useState } from "react";
 import PrintLabel from "@/components/print/PrintLabel";
+import { LABEL_SIZES, LABEL_SIZE_CONFIG } from "@/lib/label";
+import type { LabelSize } from "@/lib/label";
 
 interface Props {
   itemId: string;
   itemName: string;
   qrCodeId: string;
+  description?: string | null;
+  lowStockThreshold?: number | null;
+  canCustomizeLabels: boolean;
 }
 
-export default function PrintPageClient({ itemId, itemName, qrCodeId }: Props) {
+export default function PrintPageClient({
+  itemId,
+  itemName,
+  qrCodeId,
+  description,
+  lowStockThreshold,
+  canCustomizeLabels,
+}: Props) {
+  const [size, setSize] = useState<LabelSize>("3x1");
+  const [showDescription, setShowDescription] = useState(false);
+  const [showLowStock, setShowLowStock] = useState(false);
+
+  const labelProps = {
+    itemName,
+    qrCodeId,
+    size,
+    description,
+    lowStockThreshold,
+    showDescription: canCustomizeLabels && showDescription,
+    showLowStock: canCustomizeLabels && showLowStock,
+  };
+
+  const hasContentOptions = description || lowStockThreshold;
+
   return (
     <>
       {/* Screen view */}
       <div className="min-h-screen bg-gray-100 flex flex-col items-center justify-center gap-6 print:hidden">
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-          <PrintLabel itemName={itemName} qrCodeId={qrCodeId} />
+        {/* Controls */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-5 w-full max-w-sm">
+          {/* Size selector */}
+          <p className="text-sm font-medium text-gray-700 mb-2">Label size</p>
+          <div className="flex gap-2">
+            {LABEL_SIZES.map((s) => (
+              <button
+                key={s}
+                onClick={() => setSize(s)}
+                className={`flex-1 py-1.5 px-2 rounded text-xs font-medium border transition-colors ${
+                  size === s
+                    ? "bg-blue-600 text-white border-blue-600"
+                    : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                }`}
+              >
+                {LABEL_SIZE_CONFIG[s].label}
+              </button>
+            ))}
+          </div>
+
+          {/* Content toggles — paid plans only */}
+          {canCustomizeLabels ? (
+            <div className="mt-4">
+              <p className="text-sm font-medium text-gray-700 mb-2">Label content</p>
+              {hasContentOptions ? (
+                <div className="space-y-2">
+                  {description && (
+                    <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={showDescription}
+                        onChange={(e) => setShowDescription(e.target.checked)}
+                        className="rounded"
+                      />
+                      Show description
+                    </label>
+                  )}
+                  {lowStockThreshold && (
+                    <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={showLowStock}
+                        onChange={(e) => setShowLowStock(e.target.checked)}
+                        className="rounded"
+                      />
+                      Show low stock reminder (below {lowStockThreshold})
+                    </label>
+                  )}
+                </div>
+              ) : (
+                <p className="text-xs text-gray-400">
+                  Add a description or low stock threshold to this item to show them on the label.
+                </p>
+              )}
+            </div>
+          ) : (
+            <p className="mt-3 text-xs text-gray-400">
+              Upgrade to a paid plan to add description and low stock reminders to labels.
+            </p>
+          )}
         </div>
+
+        {/* Preview */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <p className="text-xs text-gray-500 mb-3 text-center">Preview</p>
+          <PrintLabel {...labelProps} />
+        </div>
+
         <button
           onClick={() => window.print()}
           className="bg-blue-600 text-white rounded-lg px-6 py-2 text-sm font-medium hover:bg-blue-700 transition-colors"
@@ -31,8 +125,8 @@ export default function PrintPageClient({ itemId, itemName, qrCodeId }: Props) {
       </div>
 
       {/* Print-only view */}
-      <div className="hidden print:flex print:items-center print:justify-center print:min-h-screen">
-        <PrintLabel itemName={itemName} qrCodeId={qrCodeId} />
+      <div className="hidden print:block">
+        <PrintLabel {...labelProps} />
       </div>
     </>
   );

--- a/app/(dashboard)/items/[itemId]/print/page.tsx
+++ b/app/(dashboard)/items/[itemId]/print/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
+import { TIER_LIMITS } from "@/lib/tier";
 import PrintPageClient from "./PrintPageClient";
 
 export default async function PrintPage({
@@ -16,11 +17,16 @@ export default async function PrintPage({
 
   if (!item || item.userId !== session.user.id) notFound();
 
+  const canCustomizeLabels = TIER_LIMITS[session.user.tier].customLabels;
+
   return (
     <PrintPageClient
       itemId={item.id}
       itemName={item.name}
       qrCodeId={item.qrCodeId}
+      description={item.description}
+      lowStockThreshold={item.lowStockThreshold}
+      canCustomizeLabels={canCustomizeLabels}
     />
   );
 }

--- a/components/items/ItemForm.tsx
+++ b/components/items/ItemForm.tsx
@@ -15,6 +15,9 @@ export default function ItemForm({ item, mode }: Props) {
   const [description, setDescription] = useState(item?.description ?? "");
   const [alertEmail, setAlertEmail] = useState(item?.alertEmail ?? "");
   const [imageUrl, setImageUrl] = useState(item?.imageUrl ?? "");
+  const [lowStockThreshold, setLowStockThreshold] = useState(
+    item?.lowStockThreshold != null ? String(item.lowStockThreshold) : ""
+  );
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -44,11 +47,13 @@ export default function ItemForm({ item, mode }: Props) {
     setError("");
     setLoading(true);
 
+    const threshold = lowStockThreshold ? parseInt(lowStockThreshold, 10) : null;
     const payload = {
       name,
       description: description || undefined,
       alertEmail,
       imageUrl: imageUrl || undefined,
+      lowStockThreshold: threshold && !isNaN(threshold) ? threshold : null,
     };
 
     const res = await fetch(
@@ -101,6 +106,23 @@ export default function ItemForm({ item, mode }: Props) {
           maxLength={500}
           className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
         />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Low stock threshold
+        </label>
+        <input
+          type="number"
+          value={lowStockThreshold}
+          onChange={(e) => setLowStockThreshold(e.target.value)}
+          min={1}
+          max={9999}
+          placeholder="e.g. 5"
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <p className="text-xs text-gray-400 mt-1">
+          Optional. Print this number on the label as a restock reminder.
+        </p>
       </div>
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/components/print/PrintLabel.tsx
+++ b/components/print/PrintLabel.tsx
@@ -2,41 +2,94 @@
 
 import { useEffect, useRef } from "react";
 import QRCode from "qrcode";
+import { LABEL_SIZE_CONFIG } from "@/lib/label";
+import type { LabelSize } from "@/lib/label";
 
 interface Props {
   itemName: string;
   qrCodeId: string;
+  size?: LabelSize;
+  description?: string | null;
+  lowStockThreshold?: number | null;
+  showDescription?: boolean;
+  showLowStock?: boolean;
 }
 
-export default function PrintLabel({ itemName, qrCodeId }: Props) {
+export default function PrintLabel({
+  itemName,
+  qrCodeId,
+  size = "3x1",
+  description,
+  lowStockThreshold,
+  showDescription = false,
+  showLowStock = false,
+}: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const baseUrl =
-    process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
   const url = `${baseUrl}/scan/${qrCodeId}`;
+  const config = LABEL_SIZE_CONFIG[size];
 
   useEffect(() => {
     if (canvasRef.current) {
       QRCode.toCanvas(canvasRef.current, url, {
-        width: 280,
+        width: config.qrSize,
         margin: 1,
       });
     }
-  }, [url]);
+  }, [url, config.qrSize]);
 
+  if (config.layout === "square") {
+    return (
+      <div
+        id="print-label"
+        className="flex flex-col items-center justify-center bg-white overflow-hidden"
+        style={{ width: config.width, height: config.height }}
+      >
+        <canvas ref={canvasRef} />
+        <p
+          className="text-center font-bold text-gray-900 leading-tight"
+          style={{ fontSize: "5pt", maxWidth: "0.9in" }}
+        >
+          {itemName}
+        </p>
+      </div>
+    );
+  }
+
+  // Landscape layout (3x1, 2x1)
   return (
     <div
       id="print-label"
-      className="flex flex-col items-center justify-center gap-4 p-8 bg-white"
-      style={{ width: "3.5in", minHeight: "3.5in" }}
+      className="flex flex-row items-center bg-white overflow-hidden"
+      style={{ width: config.width, height: config.height, padding: "0.05in" }}
     >
-      <canvas ref={canvasRef} />
-      <p
-        className="text-center font-bold text-gray-900 text-xl leading-tight"
-        style={{ maxWidth: "3in" }}
+      <div
+        className="flex-shrink-0 flex items-center justify-center"
+        style={{ width: `${config.qrSize}px` }}
       >
-        {itemName}
-      </p>
-      <p className="text-xs text-gray-400">Scan to request restocking</p>
+        <canvas ref={canvasRef} />
+      </div>
+      <div className="flex flex-col justify-center overflow-hidden" style={{ flex: 1, paddingLeft: "0.06in" }}>
+        <p
+          className="font-bold text-gray-900 leading-tight truncate"
+          style={{ fontSize: size === "3x1" ? "8pt" : "7pt" }}
+        >
+          {itemName}
+        </p>
+        {showDescription && description && (
+          <p className="text-gray-600 leading-tight truncate" style={{ fontSize: "6pt" }}>
+            {description}
+          </p>
+        )}
+        {showLowStock && lowStockThreshold && (
+          <p className="text-orange-600 leading-tight" style={{ fontSize: "6pt" }}>
+            Restock when below: {lowStockThreshold}
+          </p>
+        )}
+        <p className="text-gray-400 leading-tight" style={{ fontSize: "5pt" }}>
+          Scan to request restocking
+        </p>
+      </div>
     </div>
   );
 }

--- a/lib/label.ts
+++ b/lib/label.ts
@@ -1,0 +1,11 @@
+export const LABEL_SIZES = ["3x1", "2x1", "1x1"] as const;
+export type LabelSize = (typeof LABEL_SIZES)[number];
+
+export const LABEL_SIZE_CONFIG: Record<
+  LabelSize,
+  { width: string; height: string; label: string; qrSize: number; layout: "landscape" | "square" }
+> = {
+  "3x1": { width: "3in",  height: "1in", label: '3" × 1"', qrSize: 80,  layout: "landscape" },
+  "2x1": { width: "2in",  height: "1in", label: '2" × 1"', qrSize: 72,  layout: "landscape" },
+  "1x1": { width: "1in",  height: "1in", label: '1" × 1"', qrSize: 78,  layout: "square"    },
+};

--- a/lib/tier.ts
+++ b/lib/tier.ts
@@ -12,7 +12,7 @@ export const TIER_LIMITS: Record<
   },
   FAMILY: {
     maxItems: Infinity,
-    customLabels: false,
+    customLabels: true,
     label: "Family",
     price: "$9/mo",
   },

--- a/lib/validations/item.ts
+++ b/lib/validations/item.ts
@@ -5,6 +5,7 @@ export const createItemSchema = z.object({
   description: z.string().max(500).optional(),
   imageUrl: z.string().url().optional().or(z.literal("")),
   alertEmail: z.string().email("Must be a valid email address"),
+  lowStockThreshold: z.number().int().min(1).max(9999).nullable().optional(),
 });
 
 export const updateItemSchema = createItemSchema.partial();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/pg": "^8.20.0",
         "@vercel/blob": "^2.3.1",
         "bcryptjs": "^3.0.3",
-        "dotenv": "^17.3.1",
         "next": "16.2.1",
         "next-auth": "^5.0.0-beta.30",
         "pg": "^8.20.0",
@@ -33,6 +32,7 @@
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "dotenv": "^17.4.0",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -1730,9 +1730,10 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
+      "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@types/pg": "^8.20.0",
     "@vercel/blob": "^2.3.1",
     "bcryptjs": "^3.0.3",
-    "dotenv": "^17.3.1",
     "next": "16.2.1",
     "next-auth": "^5.0.0-beta.30",
     "pg": "^8.20.0",
@@ -35,6 +34,7 @@
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "dotenv": "^17.4.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/prisma/migrations/20260401000000_add_low_stock_threshold/migration.sql
+++ b/prisma/migrations/20260401000000_add_low_stock_threshold/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "InventoryItem" ADD COLUMN "lowStockThreshold" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,8 @@ model InventoryItem {
   qrCodeId          String            @unique @default(uuid())
   userId            String
 
+  lowStockThreshold Int?
+
   // Future: third-party shopping cart integration
   externalCartLink  String?
   externalPlatform  ExternalPlatform?


### PR DESCRIPTION
Free plan users can choose from three label sizes (3×1, 2×1, 1×1 inches)
on the print page. Family and Enterprise plan users additionally get toggles
to print the item description and a low stock restock reminder on the label.
Adds lowStockThreshold field to InventoryItem (set in the item edit form).

https://claude.ai/code/session_01WCPpU4rabpNeNZvWuZPkbw