### PR TITLE
Add password reset flow with forgot-password and reset-password pages

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,7 +48,9 @@
 ├── app/                          # Next.js App Router
 │   ├── (auth)/                   # Route group: unauthenticated pages
 │   │   ├── login/page.tsx
-│   │   └── register/page.tsx
+│   │   ├── register/page.tsx
+│   │   ├── forgot-password/page.tsx
+│   │   └── reset-password/page.tsx
 │   ├── (dashboard)/              # Route group: authenticated pages
 │   │   ├── layout.tsx            # Sidebar + mobile nav layout
 │   │   ├── dashboard/page.tsx
@@ -61,6 +63,8 @@
 │   ├── api/                      # API Route Handlers
 │   │   ├── auth/
 │   │   │   ├── register/route.ts
+│   │   │   ├── forgot-password/route.ts  # POST /api/auth/forgot-password (public)
+│   │   │   ├── reset-password/route.ts   # POST /api/auth/reset-password (public)
 │   │   │   └── [...nextauth]/route.ts
 │   │   ├── items/
 │   │   │   ├── route.ts          # GET /api/items, POST /api/items
@@ -95,7 +99,7 @@
 │   ├── auth.ts                   # NextAuth config (Credentials provider, JWT)
 │   ├── prisma.ts                 # Prisma client singleton
 │   ├── stripe.ts                 # Stripe client
-│   ├── resend.ts                 # Resend email client + sendAlertEmail()
+│   ├── resend.ts                 # Resend email client + sendAlertEmail() + sendPasswordResetEmail()
 │   ├── tier.ts                   # TIER_LIMITS, canCreateItem()
 │   ├── label.ts                  # LABEL_SIZES, LABEL_SIZE_CONFIG
 │   └── validations/
@@ -277,7 +281,6 @@ The current `README.md` is the default Next.js template with `Lets go` appended.
 | 6 | Item search/filter | No search or filtering on the items list page | Low |
 | 7 | Request notifications | No real-time notifications for new stocking requests (polling or websocket) | Low |
 | 8 | Image deletion | When an item is deleted, its image in Vercel Blob is not cleaned up | Low |
-| 9 | Password reset | No forgot-password / reset-password flow | Medium |
 | 10 | ENTERPRISE tier features | ENTERPRISE tier exists in the schema and pricing but has no differentiating features beyond FAMILY | Low |
 
 ---

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/forgot-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "Something went wrong.");
+      } else {
+        setSubmitted(true);
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md bg-white rounded-2xl shadow-sm border border-gray-200 p-6 sm:p-8">
+        <div className="mb-8 text-center">
+          <h1 className="text-2xl font-bold text-gray-900">InventoryAlert</h1>
+          <p className="text-gray-500 mt-1 text-sm">Reset your password</p>
+        </div>
+
+        {submitted ? (
+          <div className="text-center space-y-4">
+            <div className="bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-4 py-3">
+              If an account exists for <strong>{email}</strong>, a reset link has been sent. Check your inbox.
+            </div>
+            <Link href="/login" className="block text-sm text-blue-600 hover:underline">
+              Back to sign in
+            </Link>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {error && (
+              <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+                {error}
+              </div>
+            )}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Email address
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {loading ? "Sending…" : "Send reset link"}
+            </button>
+            <p className="text-center text-sm text-gray-500">
+              <Link href="/login" className="text-blue-600 hover:underline">
+                Back to sign in
+              </Link>
+            </p>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useState, Suspense } from "react";
 import { signIn } from "next-auth/react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
-export default function LoginPage() {
+function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const passwordReset = searchParams.get("reset") === "1";
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -30,56 +33,76 @@ export default function LoginPage() {
   }
 
   return (
+    <>
+      {passwordReset && (
+        <div className="bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-4 py-3 mb-4">
+          Password updated. You can now sign in with your new password.
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+            {error}
+          </div>
+        )}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Email
+          </label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Password
+          </label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <div className="text-right mt-1">
+            <Link href="/forgot-password" className="text-xs text-blue-600 hover:underline">
+              Forgot password?
+            </Link>
+          </div>
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        >
+          {loading ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+      <p className="text-center text-sm text-gray-500 mt-6">
+        Don&apos;t have an account?{" "}
+        <Link href="/register" className="text-blue-600 hover:underline">
+          Sign up free
+        </Link>
+      </p>
+    </>
+  );
+}
+
+export default function LoginPage() {
+  return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
       <div className="w-full max-w-md bg-white rounded-2xl shadow-sm border border-gray-200 p-6 sm:p-8">
         <div className="mb-8 text-center">
           <h1 className="text-2xl font-bold text-gray-900">InventoryAlert</h1>
           <p className="text-gray-500 mt-1 text-sm">Sign in to your account</p>
         </div>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
-              {error}
-            </div>
-          )}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Email
-            </label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Password
-            </label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-          </div>
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
-          >
-            {loading ? "Signing in…" : "Sign in"}
-          </button>
-        </form>
-        <p className="text-center text-sm text-gray-500 mt-6">
-          Don&apos;t have an account?{" "}
-          <Link href="/register" className="text-blue-600 hover:underline">
-            Sign up free
-          </Link>
-        </p>
+        <Suspense>
+          <LoginForm />
+        </Suspense>
       </div>
     </div>
   );

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+
+function ResetPasswordForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Something went wrong.");
+      } else {
+        router.push("/login?reset=1");
+      }
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!token) {
+    return (
+      <div className="text-center space-y-4">
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+          Invalid reset link. Please request a new one.
+        </div>
+        <Link href="/forgot-password" className="block text-sm text-blue-600 hover:underline">
+          Request new link
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+          {error}
+        </div>
+      )}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          New password
+        </label>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={8}
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Confirm new password
+        </label>
+        <input
+          type="password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          required
+          minLength={8}
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+      >
+        {loading ? "Saving…" : "Set new password"}
+      </button>
+      <p className="text-center text-sm text-gray-500">
+        <Link href="/login" className="text-blue-600 hover:underline">
+          Back to sign in
+        </Link>
+      </p>
+    </form>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md bg-white rounded-2xl shadow-sm border border-gray-200 p-6 sm:p-8">
+        <div className="mb-8 text-center">
+          <h1 className="text-2xl font-bold text-gray-900">InventoryAlert</h1>
+          <p className="text-gray-500 mt-1 text-sm">Choose a new password</p>
+        </div>
+        <Suspense>
+          <ResetPasswordForm />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { sendPasswordResetEmail } from "@/lib/resend";
+
+const schema = z.object({
+  email: z.string().email(),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { email } = parsed.data;
+    const user = await prisma.user.findUnique({ where: { email } });
+
+    if (user) {
+      const rawToken = crypto.randomBytes(32).toString("hex");
+      const tokenHash = crypto.createHash("sha256").update(rawToken).digest("hex");
+      const expiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { passwordResetToken: tokenHash, passwordResetExpiry: expiry },
+      });
+
+      const resetUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/reset-password?token=${rawToken}`;
+      try {
+        await sendPasswordResetEmail(email, resetUrl);
+      } catch {
+        // Log but don't expose email delivery failures
+        console.error("Failed to send password reset email to", email);
+      }
+    }
+
+    // Always return 200 to prevent user enumeration
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import bcrypt from "bcryptjs";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+
+const schema = z.object({
+  token: z.string().min(1),
+  password: z.string().min(8),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const { token, password } = parsed.data;
+    const tokenHash = crypto.createHash("sha256").update(token).digest("hex");
+
+    const user = await prisma.user.findFirst({
+      where: {
+        passwordResetToken: tokenHash,
+        passwordResetExpiry: { gt: new Date() },
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Invalid or expired reset link." },
+        { status: 400 }
+      );
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 12);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        hashedPassword,
+        passwordResetToken: null,
+        passwordResetExpiry: null,
+      },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/lib/resend.ts
+++ b/lib/resend.ts
@@ -2,6 +2,25 @@ import { Resend } from "resend";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
+export async function sendPasswordResetEmail(to: string, resetUrl: string): Promise<void> {
+  await resend.emails.send({
+    from: process.env.RESEND_FROM_EMAIL!,
+    to,
+    subject: "Reset your InventoryAlert password",
+    html: `
+      <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;">
+        <h2 style="color: #1d4ed8;">Reset Your Password</h2>
+        <p>We received a request to reset the password for your InventoryAlert account.</p>
+        <p>Click the button below to choose a new password. This link expires in <strong>1 hour</strong>.</p>
+        <a href="${resetUrl}" style="display: inline-block; margin: 16px 0; background: #2563eb; color: #fff; text-decoration: none; padding: 10px 20px; border-radius: 8px; font-size: 14px; font-weight: 600;">Reset Password</a>
+        <p>If you didn't request a password reset, you can safely ignore this email.</p>
+        <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;" />
+        <p style="color: #6b7280; font-size: 12px;">This email was sent automatically by InventoryAlert.</p>
+      </div>
+    `,
+  });
+}
+
 export async function sendAlertEmail(to: string, itemName: string): Promise<void> {
   const now = new Date().toLocaleString("en-US", { timeZone: "UTC" });
   await resend.emails.send({

--- a/prisma/migrations/20260404000000_add_password_reset_token/migration.sql
+++ b/prisma/migrations/20260404000000_add_password_reset_token/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "passwordResetExpiry" TIMESTAMP(3),
+ADD COLUMN "passwordResetToken" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,8 @@ model User {
   stripeCustomerId       String?         @unique
   stripeSubscriptionId   String?         @unique
   stripeCurrentPeriodEnd DateTime?
+  passwordResetToken     String?
+  passwordResetExpiry    DateTime?
   createdAt              DateTime        @default(now())
   updatedAt              DateTime        @updatedAt
 


### PR DESCRIPTION
## Summary
Implements a complete password reset flow for users who have forgotten their passwords. This includes a forgot-password page to request a reset link, a reset-password page to set a new password, and corresponding API endpoints to handle the reset process securely.

## Key Changes

- **New Pages:**
  - `app/(auth)/forgot-password/page.tsx` - Form to request a password reset link via email
  - `app/(auth)/reset-password/page.tsx` - Form to set a new password using a reset token from the email link

- **New API Endpoints:**
  - `POST /api/auth/forgot-password` - Generates a secure reset token, stores it in the database with 1-hour expiry, and sends a reset email
  - `POST /api/auth/reset-password` - Validates the reset token and updates the user's password

- **Updated Pages:**
  - `app/(auth)/login/page.tsx` - Refactored to use `Suspense` wrapper for search params, added "Forgot password?" link, and displays success message after password reset

- **Email Integration:**
  - Added `sendPasswordResetEmail()` function to `lib/resend.ts` to send password reset emails with a reset link

- **Database Schema:**
  - Added `passwordResetToken` and `passwordResetExpiry` fields to the User model to securely store reset tokens and their expiration times
  - Created migration to add these columns

- **Documentation:**
  - Updated `.claude/CLAUDE.md` to reflect the new routes and API endpoints

## Implementation Details

- Reset tokens are hashed using SHA-256 before storage for security
- Tokens expire after 1 hour
- The forgot-password endpoint returns 200 for all requests (whether user exists or not) to prevent user enumeration attacks
- Password validation requires minimum 8 characters
- Reset tokens are cleared from the database after successful password reset
- Uses Suspense boundaries in login page to safely access search params for the reset confirmation message

https://claude.ai/code/session_01EhbN7nVYWAfQA9BpHVbv6f