### PR TITLE
Clean up blob storage when deleting inventory items

### DIFF
--- a/app/api/items/[itemId]/route.ts
+++ b/app/api/items/[itemId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { del } from "@vercel/blob";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { updateItemSchema } from "@/lib/validations/item";
@@ -61,6 +62,10 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
   await prisma.inventoryItem.delete({ where: { id: itemId } });
+
+  if (existing.imageUrl) {
+    await del(existing.imageUrl);
+  }
 
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
Added blob storage cleanup to the item deletion endpoint to remove associated images from Vercel Blob storage when an inventory item is deleted.

## Key Changes
- Imported `del` function from `@vercel/blob` to enable blob deletion
- Added logic to delete the image blob after removing the database record, but only if an image URL exists on the item

## Implementation Details
The deletion now follows this sequence:
1. Delete the inventory item from the database
2. If the item had an associated image URL, delete the blob from Vercel Blob storage

This prevents orphaned image files from accumulating in blob storage when items are deleted, improving storage efficiency and data cleanup.

https://claude.ai/code/session_0132cJnJHmuADxoNXzB1gneF