### PR TITLE
feat: M3 UI redesign + per-item alert email toggle

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -28,13 +28,13 @@ export default async function DashboardPage() {
   return (
     <div className="space-y-8">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+        <h1 className="text-2xl font-bold text-on-surface font-headline">Dashboard</h1>
         <TierBadge tier={tier} />
       </div>
 
       {/* Stats */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <StatCard
+        <HeroStatCard
           label="Inventory Items"
           value={
             limit.maxItems === Infinity
@@ -60,30 +60,30 @@ export default async function DashboardPage() {
       {/* Recent stocking requests */}
       <div>
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-base font-semibold text-gray-900">
+          <h2 className="text-base font-semibold text-on-surface font-headline">
             Recent Stocking Requests
           </h2>
           <Link
             href="/requests"
-            className="text-sm text-blue-600 hover:underline"
+            className="text-sm text-secondary hover:underline"
           >
             View all
           </Link>
         </div>
         {recentRequests.length === 0 ? (
-          <div className="text-sm text-gray-500 bg-white border border-gray-200 rounded-xl px-5 py-8 text-center">
+          <div className="text-sm text-on-surface-variant bg-surface-container-lowest rounded-xl px-5 py-8 text-center">
             No stocking requests yet. When a QR code is scanned, requests will
             appear here.
           </div>
         ) : (
-          <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
-            <ul className="divide-y divide-gray-100 md:hidden">
+          <div className="bg-surface-container-lowest rounded-xl overflow-hidden">
+            <ul className="divide-y divide-outline-variant md:hidden">
               {recentRequests.map((r) => (
                 <li key={r.id} className="px-4 py-3">
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
-                      <p className="font-medium text-sm text-gray-900 truncate">{r.item.name}</p>
-                      <p className="text-xs text-gray-500 mt-1">
+                      <p className="font-medium text-sm text-on-surface truncate">{r.item.name}</p>
+                      <p className="text-xs text-on-surface-variant mt-1">
                         {new Date(r.createdAt).toLocaleString()}
                       </p>
                     </div>
@@ -95,22 +95,22 @@ export default async function DashboardPage() {
             <div className="hidden md:block overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-gray-100 bg-gray-50 text-left">
-                  <th className="px-4 py-3 font-medium text-gray-600">Item</th>
-                  <th className="px-4 py-3 font-medium text-gray-600">When</th>
-                  <th className="px-4 py-3 font-medium text-gray-600">Status</th>
+                <tr className="border-b border-outline-variant bg-surface-container text-left">
+                  <th className="px-4 py-3 font-medium text-on-surface-variant">Item</th>
+                  <th className="px-4 py-3 font-medium text-on-surface-variant">When</th>
+                  <th className="px-4 py-3 font-medium text-on-surface-variant">Status</th>
                 </tr>
               </thead>
               <tbody>
                 {recentRequests.map((r) => (
                   <tr
                     key={r.id}
-                    className="border-b border-gray-50 last:border-0"
+                    className="border-b border-outline-variant last:border-0"
                   >
-                    <td className="px-4 py-3 font-medium text-gray-900">
+                    <td className="px-4 py-3 font-medium text-on-surface">
                       {r.item.name}
                     </td>
-                    <td className="px-4 py-3 text-gray-500">
+                    <td className="px-4 py-3 text-on-surface-variant">
                       {new Date(r.createdAt).toLocaleString()}
                     </td>
                     <td className="px-4 py-3">
@@ -128,6 +128,29 @@ export default async function DashboardPage() {
   );
 }
 
+function HeroStatCard({
+  label,
+  value,
+  sub,
+  href,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  href: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="bg-gradient-to-br from-primary to-primary-container text-white rounded-xl p-5 hover:opacity-90 transition-opacity"
+    >
+      <p className="text-sm text-white/70 mb-1">{label}</p>
+      <p className="text-2xl text-white font-headline font-bold">{value}</p>
+      {sub && <p className="text-xs text-white/60 mt-1">{sub}</p>}
+    </Link>
+  );
+}
+
 function StatCard({
   label,
   value,
@@ -142,25 +165,25 @@ function StatCard({
   return (
     <Link
       href={href}
-      className="bg-white border border-gray-200 rounded-xl p-5 hover:border-blue-200 transition-colors"
+      className="bg-surface-container-lowest rounded-xl shadow-sm p-5 hover:shadow-md transition-shadow"
     >
-      <p className="text-sm text-gray-500 mb-1">{label}</p>
-      <p className="text-2xl font-bold text-gray-900">{value}</p>
-      {sub && <p className="text-xs text-gray-400 mt-1">{sub}</p>}
+      <p className="text-sm text-on-surface-variant mb-1">{label}</p>
+      <p className="text-2xl text-on-surface font-headline font-bold">{value}</p>
+      {sub && <p className="text-xs text-on-surface-variant mt-1">{sub}</p>}
     </Link>
   );
 }
 
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
-    PENDING: "bg-yellow-50 text-yellow-700",
-    APPROVED: "bg-green-50 text-green-700",
-    DECLINED: "bg-red-50 text-red-700",
+    PENDING: "bg-tertiary-fixed/60 text-on-tertiary-container",
+    APPROVED: "bg-secondary-container/40 text-on-secondary-container",
+    DECLINED: "bg-error-container text-on-error-container",
   };
   return (
     <span
       className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
-        styles[status] ?? "bg-gray-100 text-gray-600"
+        styles[status] ?? "bg-surface-container-high text-on-surface-variant"
       }`}
     >
       {status.charAt(0) + status.slice(1).toLowerCase()}

--- a/app/(dashboard)/items/[itemId]/page.tsx
+++ b/app/(dashboard)/items/[itemId]/page.tsx
@@ -21,20 +21,20 @@ export default async function EditItemPage({
   return (
     <div className="max-w-lg">
       <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
-        <h1 className="text-2xl font-bold text-gray-900">Edit Item</h1>
+        <h1 className="text-2xl font-bold text-on-surface font-headline">Edit Item</h1>
         <Link
           href={`/items/${item.id}/print`}
           target="_blank"
-          className="w-full sm:w-auto text-center border border-gray-300 text-gray-700 rounded-lg px-4 py-2 text-sm hover:bg-gray-50 transition-colors"
+          className="w-full sm:w-auto text-center border border-outline text-on-surface rounded-full px-4 py-2 text-sm hover:bg-surface-container-low transition-colors"
         >
           Print label
         </Link>
       </div>
 
-      <div className="bg-white border border-gray-200 rounded-xl p-5 flex flex-col items-center mb-6">
-        <p className="text-xs text-gray-500 mb-3">QR Code</p>
+      <div className="bg-surface-container-lowest rounded-xl p-5 flex flex-col items-center mb-6 shadow-sm">
+        <p className="text-xs text-on-surface-variant mb-3">QR Code</p>
         <QRCodeDisplay qrCodeId={item.qrCodeId} size={180} />
-        <p className="text-xs text-gray-400 mt-3 break-all text-center">
+        <p className="text-xs text-outline mt-3 break-all text-center">
           {process.env.NEXT_PUBLIC_BASE_URL}/scan/{item.qrCodeId}
         </p>
       </div>

--- a/app/(dashboard)/items/new/page.tsx
+++ b/app/(dashboard)/items/new/page.tsx
@@ -18,16 +18,16 @@ export default async function NewItemPage() {
     const limit = TIER_LIMITS[session.user.tier];
     return (
       <div className="max-w-lg">
-        <h1 className="text-2xl font-bold text-gray-900 mb-6">New Item</h1>
-        <div className="bg-orange-50 border border-orange-200 rounded-xl p-6 text-center">
-          <p className="font-semibold text-gray-900 mb-2">Item limit reached</p>
-          <p className="text-sm text-gray-600 mb-4">
+        <h1 className="text-2xl font-bold text-on-surface font-headline mb-6">New Item</h1>
+        <div className="bg-error-container rounded-xl p-6 text-center">
+          <p className="font-semibold text-on-error-container mb-2">Item limit reached</p>
+          <p className="text-sm text-on-error-container mb-4">
             Your {limit.label} plan allows up to {limit.maxItems} items. You
             have {count}.
           </p>
           <Link
             href="/settings"
-            className="inline-block bg-orange-500 text-white rounded-lg px-5 py-2 text-sm font-medium hover:bg-orange-600 transition-colors"
+            className="inline-block bg-error text-on-error rounded-full px-5 py-2 text-sm font-medium hover:opacity-90 transition-colors"
           >
             Upgrade plan
           </Link>
@@ -38,7 +38,7 @@ export default async function NewItemPage() {
 
   return (
     <div className="max-w-lg">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">New Item</h1>
+      <h1 className="text-2xl font-bold text-on-surface font-headline mb-6">New Item</h1>
       <ItemForm mode="create" />
     </div>
   );

--- a/app/(dashboard)/items/page.tsx
+++ b/app/(dashboard)/items/page.tsx
@@ -21,9 +21,9 @@ export default async function ItemsPage() {
     <div className="space-y-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Inventory</h1>
+          <h1 className="text-2xl font-bold text-on-surface font-headline">Inventory</h1>
           {limit.maxItems !== Infinity && (
-            <p className="text-sm text-gray-500 mt-0.5">
+            <p className="text-sm text-on-surface-variant mt-0.5">
               {items.length} / {limit.maxItems} items used
             </p>
           )}
@@ -31,14 +31,14 @@ export default async function ItemsPage() {
         {atLimit ? (
           <Link
             href="/settings"
-            className="w-full sm:w-auto text-center bg-orange-500 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-orange-600 transition-colors"
+            className="w-full sm:w-auto text-center bg-secondary text-on-secondary rounded-full px-4 py-2 text-sm font-medium hover:opacity-90 transition-colors"
           >
             Upgrade to add more
           </Link>
         ) : (
           <Link
             href="/items/new"
-            className="w-full sm:w-auto text-center bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 transition-colors"
+            className="w-full sm:w-auto text-center bg-primary text-on-primary rounded-full px-4 py-2 text-sm font-medium hover:bg-primary-container transition-colors"
           >
             + New item
           </Link>
@@ -46,8 +46,8 @@ export default async function ItemsPage() {
       </div>
 
       {items.length === 0 ? (
-        <div className="text-center py-20 text-gray-500">
-          <p className="text-lg font-medium text-gray-700 mb-2">
+        <div className="text-center py-20 text-on-surface-variant">
+          <p className="text-lg font-medium text-on-surface mb-2">
             No items yet
           </p>
           <p className="text-sm mb-6">
@@ -55,7 +55,7 @@ export default async function ItemsPage() {
           </p>
           <Link
             href="/items/new"
-            className="bg-blue-600 text-white rounded-lg px-5 py-2 text-sm font-medium hover:bg-blue-700 transition-colors"
+            className="bg-primary text-on-primary rounded-full px-4 py-2 text-sm font-medium hover:bg-primary-container transition-colors"
           >
             Create first item
           </Link>

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import Sidebar from "@/components/layout/Sidebar";
 import MobileHeader from "@/components/layout/MobileHeader";
 import BottomNav from "@/components/layout/BottomNav";
 import { SessionProvider } from "next-auth/react";
+import Link from "next/link";
 
 export default async function DashboardLayout({
   children,
@@ -15,7 +16,7 @@ export default async function DashboardLayout({
 
   return (
     <SessionProvider session={session}>
-      <div className="flex flex-col min-h-screen bg-gray-50">
+      <div className="flex flex-col min-h-screen bg-background">
         <MobileHeader />
         <div className="flex flex-1">
           <Sidebar />
@@ -24,6 +25,13 @@ export default async function DashboardLayout({
           </main>
         </div>
         <BottomNav />
+        <Link
+          href="/items/new"
+          className="fixed bottom-28 right-6 z-40 md:hidden w-14 h-14 flex items-center justify-center bg-gradient-to-br from-primary to-primary-container text-white rounded-2xl shadow-lg active:scale-95 transition-transform"
+          aria-label="Add new item"
+        >
+          <span className="material-symbols-outlined">add</span>
+        </Link>
       </div>
     </SessionProvider>
   );

--- a/app/(dashboard)/requests/RequestsClient.tsx
+++ b/app/(dashboard)/requests/RequestsClient.tsx
@@ -27,9 +27,9 @@ const TABS: { label: string; value: RequestStatus | null }[] = [
 ];
 
 const statusStyles: Record<RequestStatus, string> = {
-  PENDING: "bg-yellow-50 text-yellow-700",
-  APPROVED: "bg-green-50 text-green-700",
-  DECLINED: "bg-red-50 text-red-700",
+  PENDING: "bg-tertiary-fixed/60 text-on-tertiary-container",
+  APPROVED: "bg-secondary-container/40 text-on-secondary-container",
+  DECLINED: "bg-error-container text-on-error-container",
 };
 
 export default function RequestsClient({ initialRequests, activeStatus }: Props) {
@@ -83,15 +83,15 @@ export default function RequestsClient({ initialRequests, activeStatus }: Props)
     <div>
       {/* Tabs */}
       <div className="overflow-x-auto mb-5">
-      <div className="flex gap-1 bg-gray-100 rounded-lg p-1 w-fit">
+      <div className="flex gap-1 bg-surface-container rounded-2xl p-1 w-fit">
         {TABS.map((tab) => (
           <button
             key={tab.label}
             onClick={() => handleTabChange(tab.value)}
-            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            className={`px-4 py-1.5 rounded-xl text-sm font-medium transition-colors ${
               activeStatus === tab.value
-                ? "bg-white text-gray-900 shadow-sm"
-                : "text-gray-500 hover:text-gray-700"
+                ? "bg-primary text-on-primary shadow-sm"
+                : "text-on-surface-variant hover:text-on-surface"
             }`}
           >
             {tab.label}
@@ -101,28 +101,28 @@ export default function RequestsClient({ initialRequests, activeStatus }: Props)
       </div>
 
       {requests.length === 0 ? (
-        <div className="text-center py-16 text-gray-500 bg-white border border-gray-200 rounded-xl">
+        <div className="text-center py-16 text-on-surface-variant bg-surface-container-lowest rounded-xl">
           <p className="text-sm">No requests found.</p>
         </div>
       ) : (
-        <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
+        <div className="bg-surface-container-lowest rounded-xl overflow-hidden">
           <div className="hidden md:block overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-100 bg-gray-50 text-left">
-                <th className="px-4 py-3 font-medium text-gray-600">Item</th>
-                <th className="px-4 py-3 font-medium text-gray-600">Requested</th>
-                <th className="px-4 py-3 font-medium text-gray-600">Status</th>
-                <th className="px-4 py-3 font-medium text-gray-600">Actions</th>
+              <tr className="border-b border-outline-variant bg-surface-container text-left">
+                <th className="px-4 py-3 font-medium text-on-surface-variant">Item</th>
+                <th className="px-4 py-3 font-medium text-on-surface-variant">Requested</th>
+                <th className="px-4 py-3 font-medium text-on-surface-variant">Status</th>
+                <th className="px-4 py-3 font-medium text-on-surface-variant">Actions</th>
               </tr>
             </thead>
             <tbody>
               {requests.map((r) => (
-                <tr key={r.id} className="border-b border-gray-50 last:border-0">
-                  <td className="px-4 py-3 font-medium text-gray-900">
+                <tr key={r.id} className="border-b border-outline-variant last:border-0">
+                  <td className="px-4 py-3 font-medium text-on-surface">
                     {r.item.name}
                   </td>
-                  <td className="px-4 py-3 text-gray-500">
+                  <td className="px-4 py-3 text-on-surface-variant">
                     {new Date(r.createdAt).toLocaleString()}
                   </td>
                   <td className="px-4 py-3">
@@ -146,13 +146,13 @@ export default function RequestsClient({ initialRequests, activeStatus }: Props)
             </tbody>
           </table>
           </div>
-          <ul className="divide-y divide-gray-100 md:hidden">
+          <ul className="divide-y divide-outline-variant md:hidden">
             {requests.map((r) => (
               <li key={r.id} className="px-4 py-3">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <p className="font-medium text-sm text-gray-900 truncate">{r.item.name}</p>
-                    <p className="text-xs text-gray-500 mt-1">
+                    <p className="font-medium text-sm text-on-surface truncate">{r.item.name}</p>
+                    <p className="text-xs text-on-surface-variant mt-1">
                       {new Date(r.createdAt).toLocaleString()}
                     </p>
                   </div>
@@ -197,7 +197,7 @@ function ActionButtons({
   mobile?: boolean;
 }) {
   if (requestStatus !== "PENDING") {
-    return <span className="text-xs text-gray-400">—</span>;
+    return <span className="text-xs text-on-surface-variant">—</span>;
   }
 
   return (
@@ -205,14 +205,14 @@ function ActionButtons({
       <button
         onClick={() => onApprove(requestId, "APPROVED")}
         disabled={loading === requestId}
-        className="px-3 py-2 text-xs font-medium bg-green-50 text-green-700 border border-green-200 rounded hover:bg-green-100 disabled:opacity-50 transition-colors"
+        className="px-3 py-2 text-xs font-medium bg-secondary-container/30 text-on-secondary-container border border-secondary/20 rounded-lg hover:bg-secondary-container/50 disabled:opacity-50 transition-colors"
       >
         Approve
       </button>
       <button
         onClick={() => onDecline(requestId, "DECLINED")}
         disabled={loading === requestId}
-        className="px-3 py-2 text-xs font-medium bg-red-50 text-red-700 border border-red-200 rounded hover:bg-red-100 disabled:opacity-50 transition-colors"
+        className="px-3 py-2 text-xs font-medium bg-error-container text-on-error-container border border-error/20 rounded-lg hover:opacity-80 disabled:opacity-50 transition-colors"
       >
         Decline
       </button>

--- a/app/(dashboard)/settings/SettingsClient.tsx
+++ b/app/(dashboard)/settings/SettingsClient.tsx
@@ -45,24 +45,24 @@ export default function SettingsClient({ currentTier, hasSubscription }: Props) 
   return (
     <div className="space-y-3 pt-2">
       {error && (
-        <p className="text-sm text-red-600">{error}</p>
+        <p className="text-sm text-error">{error}</p>
       )}
 
       {currentTier === "FREE" && (
         <div className="space-y-2">
-          <p className="text-sm text-gray-600 font-medium">Upgrade your plan</p>
+          <p className="text-sm text-on-surface-variant font-medium">Upgrade your plan</p>
           <div className="flex flex-col gap-2 sm:flex-row">
             <button
               onClick={() => handleUpgrade("FAMILY")}
               disabled={!!loading}
-              className="flex-1 border border-blue-200 bg-blue-50 text-blue-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-100 disabled:opacity-50 transition-colors"
+              className="flex-1 bg-primary text-on-primary rounded-full border-0 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
             >
               {loading === "FAMILY" ? "Loading…" : "Family — $9/mo"}
             </button>
             <button
               onClick={() => handleUpgrade("ENTERPRISE")}
               disabled={!!loading}
-              className="flex-1 border border-purple-200 bg-purple-50 text-purple-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-purple-100 disabled:opacity-50 transition-colors"
+              className="flex-1 bg-primary-container text-on-primary-container rounded-full border border-primary/20 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
             >
               {loading === "ENTERPRISE" ? "Loading…" : "Enterprise — $29/mo"}
             </button>
@@ -75,7 +75,7 @@ export default function SettingsClient({ currentTier, hasSubscription }: Props) 
           <button
             onClick={() => handleUpgrade("ENTERPRISE")}
             disabled={!!loading}
-            className="w-full sm:flex-1 border border-purple-200 bg-purple-50 text-purple-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-purple-100 disabled:opacity-50 transition-colors"
+            className="w-full sm:flex-1 bg-primary-container text-on-primary-container rounded-full border border-primary/20 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
           >
             {loading === "ENTERPRISE" ? "Loading…" : "Upgrade to Enterprise — $29/mo"}
           </button>
@@ -83,7 +83,7 @@ export default function SettingsClient({ currentTier, hasSubscription }: Props) 
             <button
               onClick={handlePortal}
               disabled={!!loading}
-              className="w-full sm:w-auto border border-gray-300 text-gray-600 rounded-lg px-4 py-2 text-sm hover:bg-gray-50 disabled:opacity-50 transition-colors"
+              className="w-full sm:w-auto border border-outline text-on-surface-variant rounded-full px-4 py-2 text-sm hover:bg-surface-container disabled:opacity-50 transition-colors"
             >
               {loading === "portal" ? "Loading…" : "Manage billing"}
             </button>
@@ -95,7 +95,7 @@ export default function SettingsClient({ currentTier, hasSubscription }: Props) 
         <button
           onClick={handlePortal}
           disabled={!!loading}
-          className="border border-gray-300 text-gray-600 rounded-lg px-4 py-2 text-sm hover:bg-gray-50 disabled:opacity-50 transition-colors"
+          className="border border-outline text-on-surface-variant rounded-full px-4 py-2 text-sm hover:bg-surface-container disabled:opacity-50 transition-colors"
         >
           {loading === "portal" ? "Loading…" : "Manage billing / Cancel"}
         </button>

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -29,44 +29,44 @@ export default async function SettingsPage() {
 
   return (
     <div className="max-w-lg space-y-8">
-      <h1 className="text-2xl font-bold text-gray-900">Settings</h1>
+      <h1 className="text-2xl font-bold text-on-surface font-headline">Settings</h1>
 
       {/* Account */}
-      <section className="bg-white border border-gray-200 rounded-xl p-4 sm:p-6 space-y-3">
-        <h2 className="font-semibold text-gray-900">Account</h2>
-        <div className="text-sm text-gray-600">
+      <section className="bg-surface-container-lowest rounded-xl shadow-sm p-4 sm:p-6 space-y-3">
+        <h2 className="font-semibold text-on-surface font-headline">Account</h2>
+        <div className="text-sm text-on-surface-variant">
           <p>
-            <span className="text-gray-400">Name:</span>{" "}
+            <span className="text-outline">Name:</span>{" "}
             {user.name ?? "—"}
           </p>
           <p className="mt-1">
-            <span className="text-gray-400">Email:</span> {user.email}
+            <span className="text-outline">Email:</span> {user.email}
           </p>
         </div>
       </section>
 
       {/* Plan */}
-      <section className="bg-white border border-gray-200 rounded-xl p-4 sm:p-6 space-y-4">
+      <section className="bg-surface-container-lowest rounded-xl shadow-sm p-4 sm:p-6 space-y-4">
         <div className="flex items-center justify-between">
-          <h2 className="font-semibold text-gray-900">Current Plan</h2>
+          <h2 className="font-semibold text-on-surface font-headline">Current Plan</h2>
           <TierBadge tier={tier} />
         </div>
 
-        <div className="text-sm text-gray-600 space-y-1">
+        <div className="text-sm text-on-surface-variant space-y-1">
           <p>
-            <span className="text-gray-400">Price:</span> {limit.price}
+            <span className="text-outline">Price:</span> {limit.price}
           </p>
           <p>
-            <span className="text-gray-400">Item limit:</span>{" "}
+            <span className="text-outline">Item limit:</span>{" "}
             {limit.maxItems === Infinity ? "Unlimited" : limit.maxItems}
           </p>
           <p>
-            <span className="text-gray-400">Items used:</span> {itemCount}
+            <span className="text-outline">Items used:</span> {itemCount}
             {limit.maxItems !== Infinity && ` / ${limit.maxItems}`}
           </p>
           {user.stripeCurrentPeriodEnd && (
             <p>
-              <span className="text-gray-400">Renews:</span>{" "}
+              <span className="text-outline">Renews:</span>{" "}
               {new Date(user.stripeCurrentPeriodEnd).toLocaleDateString()}
             </p>
           )}
@@ -75,15 +75,15 @@ export default async function SettingsPage() {
         {/* Progress bar for free tier */}
         {limit.maxItems !== Infinity && (
           <div>
-            <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+            <div className="h-2 bg-surface-container-high rounded-full overflow-hidden">
               <div
-                className="h-full bg-blue-500 rounded-full transition-all"
+                className="h-full bg-secondary rounded-full transition-all"
                 style={{
                   width: `${Math.min(100, (itemCount / limit.maxItems) * 100)}%`,
                 }}
               />
             </div>
-            <p className="text-xs text-gray-400 mt-1">
+            <p className="text-xs text-outline mt-1">
               {itemCount} of {limit.maxItems} items used
             </p>
           </div>

--- a/app/api/scan/[qrCodeId]/route.ts
+++ b/app/api/scan/[qrCodeId]/route.ts
@@ -15,6 +15,14 @@ export async function POST(_req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: "Item not found" }, { status: 404 });
   }
 
+  // If alert emails are disabled for this item, record the scan but skip email
+  if (item.alertEmailEnabled === false) {
+    await prisma.stockingRequest.create({
+      data: { itemId: item.id, emailSent: false },
+    });
+    return NextResponse.json({ alreadyNotified: false, itemName: item.name });
+  }
+
   // Check for a recent email-sent request within the last 60 minutes
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
   const recentEmailSent = await prisma.stockingRequest.findFirst({

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,28 +1,66 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+@theme {
+  --color-primary: #031635;
+  --color-primary-container: #1a2b4b;
+  --color-primary-fixed: #d8e2ff;
+  --color-primary-fixed-dim: #b6c6ef;
+  --color-on-primary: #ffffff;
+  --color-on-primary-fixed: #081b3a;
+  --color-on-primary-fixed-variant: #364768;
+  --color-on-primary-container: #8293b8;
+  --color-secondary: #006c49;
+  --color-secondary-container: #6cf8bb;
+  --color-secondary-fixed: #6ffbbe;
+  --color-secondary-fixed-dim: #4edea3;
+  --color-on-secondary: #ffffff;
+  --color-on-secondary-container: #00714d;
+  --color-on-secondary-fixed: #002113;
+  --color-on-secondary-fixed-variant: #005236;
+  --color-tertiary: #241300;
+  --color-tertiary-container: #402600;
+  --color-tertiary-fixed: #ffddb8;
+  --color-tertiary-fixed-dim: #ffb95f;
+  --color-on-tertiary: #ffffff;
+  --color-on-tertiary-container: #cd8300;
+  --color-on-tertiary-fixed: #2a1700;
+  --color-on-tertiary-fixed-variant: #653e00;
+  --color-surface: #f7f9fb;
+  --color-surface-bright: #f7f9fb;
+  --color-surface-dim: #d8dadc;
+  --color-surface-variant: #e0e3e5;
+  --color-surface-container-lowest: #ffffff;
+  --color-surface-container-low: #f2f4f6;
+  --color-surface-container: #eceef0;
+  --color-surface-container-high: #e6e8ea;
+  --color-surface-container-highest: #e0e3e5;
+  --color-surface-tint: #4e5e81;
+  --color-on-surface: #191c1e;
+  --color-on-surface-variant: #44474e;
+  --color-on-background: #191c1e;
+  --color-background: #f7f9fb;
+  --color-inverse-surface: #2d3133;
+  --color-inverse-primary: #b6c6ef;
+  --color-inverse-on-surface: #eff1f3;
+  --color-outline: #75777f;
+  --color-outline-variant: #c5c6cf;
+  --color-error: #ba1a1a;
+  --color-error-container: #ffdad6;
+  --color-on-error: #ffffff;
+  --color-on-error-container: #93000a;
+  --font-headline: 'Plus Jakarta Sans', sans-serif;
+  --font-body: 'Inter', sans-serif;
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-body);
+  background-color: var(--color-background);
+  color: var(--color-on-surface);
+}
+
+.material-symbols-outlined {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+  user-select: none;
 }
 
 /* Progressive enhancement: scroll-linked reveal animations on supported browsers */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,17 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Plus_Jakarta_Sans, Inter } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const plusJakartaSans = Plus_Jakarta_Sans({
+  variable: "--font-headline",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700", "800"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const inter = Inter({
+  variable: "--font-body",
   subsets: ["latin"],
+  weight: ["400", "500", "600"],
 });
 
 export const metadata: Metadata = {
@@ -25,8 +27,14 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${plusJakartaSans.variable} ${inter.variable} h-full antialiased`}
     >
+      <head>
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
+        />
+      </head>
       <body className="min-h-full flex flex-col">{children}</body>
     </html>
   );

--- a/components/items/ItemCard.tsx
+++ b/components/items/ItemCard.tsx
@@ -18,22 +18,28 @@ export default function ItemCard({ item }: { item: InventoryItem }) {
   }
 
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-5 flex flex-col gap-4">
+    <div className="bg-surface-container-lowest rounded-xl p-5 flex flex-col gap-4 shadow-sm">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <h3 className="font-semibold text-gray-900 truncate">{item.name}</h3>
+          <h3 className="font-semibold text-on-surface truncate">{item.name}</h3>
           {item.description && (
-            <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">
+            <p className="text-xs text-on-surface-variant mt-0.5 line-clamp-2">
               {item.description}
             </p>
           )}
-          <p className="text-xs text-gray-400 mt-1">{item.alertEmail}</p>
+          <p className="text-xs text-outline mt-1">{item.alertEmail}</p>
+          {item.alertEmailEnabled === false && (
+            <span className="inline-flex items-center gap-1 mt-1.5 px-2 py-0.5 rounded-full bg-surface-container-high text-on-surface-variant text-[10px] font-medium">
+              <span className="material-symbols-outlined text-[12px] leading-none">notifications_off</span>
+              Alerts off
+            </span>
+          )}
         </div>
         {item.imageUrl && (
           <img
             src={item.imageUrl}
             alt={item.name}
-            className="w-12 h-12 object-cover rounded-lg border border-gray-100 flex-shrink-0"
+            className="w-12 h-12 object-cover rounded-lg border border-outline-variant flex-shrink-0"
           />
         )}
       </div>
@@ -45,21 +51,21 @@ export default function ItemCard({ item }: { item: InventoryItem }) {
       <div className="grid grid-cols-1 gap-2 pt-1 sm:grid-cols-3">
         <Link
           href={`/items/${item.id}`}
-          className="text-center border border-gray-300 text-gray-700 rounded-lg px-3 py-2 text-xs font-medium hover:bg-gray-50 transition-colors"
+          className="text-center border border-outline text-on-surface rounded-full px-3 py-2 text-xs font-medium hover:bg-surface-container-low transition-colors"
         >
           Edit
         </Link>
         <Link
           href={`/items/${item.id}/print`}
           target="_blank"
-          className="text-center border border-gray-300 text-gray-700 rounded-lg px-3 py-2 text-xs font-medium hover:bg-gray-50 transition-colors"
+          className="text-center border border-outline text-on-surface rounded-full px-3 py-2 text-xs font-medium hover:bg-surface-container-low transition-colors"
         >
           Print label
         </Link>
         <button
           onClick={handleDelete}
           disabled={deleting}
-          className="border border-red-200 text-red-600 rounded-lg px-3 py-2 text-xs font-medium hover:bg-red-50 disabled:opacity-50 transition-colors"
+          className="border border-error/30 text-error rounded-full px-3 py-2 text-xs font-medium hover:bg-error-container disabled:opacity-50 transition-colors"
         >
           {deleting ? "…" : "Delete"}
         </button>

--- a/components/items/ItemForm.tsx
+++ b/components/items/ItemForm.tsx
@@ -18,6 +18,9 @@ export default function ItemForm({ item, mode }: Props) {
   const [lowStockThreshold, setLowStockThreshold] = useState(
     item?.lowStockThreshold != null ? String(item.lowStockThreshold) : ""
   );
+  const [alertEmailEnabled, setAlertEmailEnabled] = useState(
+    item?.alertEmailEnabled ?? true
+  );
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -54,6 +57,7 @@ export default function ItemForm({ item, mode }: Props) {
       alertEmail,
       imageUrl: imageUrl || undefined,
       lowStockThreshold: threshold && !isNaN(threshold) ? threshold : null,
+      alertEmailEnabled,
     };
 
     const res = await fetch(
@@ -78,13 +82,13 @@ export default function ItemForm({ item, mode }: Props) {
   return (
     <form onSubmit={handleSubmit} className="space-y-5 max-w-lg">
       {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+        <div className="bg-error-container border border-error/20 text-on-error-container text-sm rounded-lg px-4 py-3">
           {error}
         </div>
       )}
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          Item name <span className="text-red-500">*</span>
+        <label className="block text-sm font-medium text-on-surface-variant mb-1">
+          Item name <span className="text-error">*</span>
         </label>
         <input
           type="text"
@@ -92,11 +96,11 @@ export default function ItemForm({ item, mode }: Props) {
           onChange={(e) => setName(e.target.value)}
           required
           maxLength={100}
-          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
         />
       </div>
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-on-surface-variant mb-1">
           Description
         </label>
         <textarea
@@ -104,11 +108,11 @@ export default function ItemForm({ item, mode }: Props) {
           onChange={(e) => setDescription(e.target.value)}
           rows={3}
           maxLength={500}
-          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+          className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface resize-none"
         />
       </div>
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-on-surface-variant mb-1">
           Low stock threshold
         </label>
         <input
@@ -118,37 +122,60 @@ export default function ItemForm({ item, mode }: Props) {
           min={1}
           max={9999}
           placeholder="e.g. 5"
-          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
         />
-        <p className="text-xs text-gray-400 mt-1">
+        <p className="text-xs text-outline mt-1">
           Optional. Print this number on the label as a restock reminder.
         </p>
       </div>
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          Alert email <span className="text-red-500">*</span>
+        <label className="block text-sm font-medium text-on-surface-variant mb-1">
+          Alert email <span className="text-error">*</span>
         </label>
         <input
           type="email"
           value={alertEmail}
           onChange={(e) => setAlertEmail(e.target.value)}
           required
-          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
           placeholder="alerts@yourcompany.com"
         />
-        <p className="text-xs text-gray-400 mt-1">
+        <p className="text-xs text-outline mt-1">
           This address receives low stock alerts when the QR code is scanned.
         </p>
       </div>
+      <div className="flex items-center justify-between py-1">
+        <div>
+          <p className="text-sm font-medium text-on-surface">Alert emails</p>
+          <p className="text-xs text-outline mt-0.5">
+            Send an email when this item&apos;s QR code is scanned
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={alertEmailEnabled}
+          onClick={() => setAlertEmailEnabled((v) => !v)}
+          className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 ${
+            alertEmailEnabled ? "bg-secondary" : "bg-outline-variant"
+          }`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+              alertEmailEnabled ? "translate-x-6" : "translate-x-1"
+            }`}
+          />
+        </button>
+      </div>
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-on-surface-variant mb-1">
           Image (optional)
         </label>
         {imageUrl && (
           <img
             src={imageUrl}
             alt="Item"
-            className="w-24 h-24 object-cover rounded-lg mb-2 border border-gray-200"
+            className="w-24 h-24 object-cover rounded-lg mb-2 border border-outline-variant"
           />
         )}
         <input
@@ -156,17 +183,17 @@ export default function ItemForm({ item, mode }: Props) {
           accept="image/jpeg,image/png,image/webp"
           onChange={handleImageChange}
           disabled={uploading}
-          className="block text-sm text-gray-500 file:mr-3 file:py-1.5 file:px-3 file:rounded file:border-0 file:text-xs file:font-medium file:bg-gray-100 file:text-gray-700 hover:file:bg-gray-200"
+          className="block text-sm text-on-surface-variant file:mr-3 file:py-1.5 file:px-3 file:rounded file:border-0 file:text-xs file:font-medium file:bg-surface-container file:text-on-surface-variant hover:file:bg-surface-container-high"
         />
         {uploading && (
-          <p className="text-xs text-blue-600 mt-1">Uploading…</p>
+          <p className="text-xs text-secondary mt-1">Uploading…</p>
         )}
       </div>
       <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row">
         <button
           type="submit"
           disabled={loading || uploading}
-          className="w-full sm:w-auto bg-blue-600 text-white rounded-lg px-5 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          className="w-full sm:w-auto bg-primary text-on-primary rounded-full px-5 py-2 text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors"
         >
           {loading
             ? mode === "create"
@@ -179,7 +206,7 @@ export default function ItemForm({ item, mode }: Props) {
         <button
           type="button"
           onClick={() => router.back()}
-          className="w-full sm:w-auto border border-gray-300 text-gray-700 rounded-lg px-5 py-2 text-sm hover:bg-gray-50 transition-colors"
+          className="w-full sm:w-auto border border-outline text-on-surface rounded-full px-5 py-2 text-sm hover:bg-surface-container-low transition-colors"
         >
           Cancel
         </button>

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -4,43 +4,10 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const navItems = [
-  {
-    href: "/dashboard",
-    label: "Dashboard",
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={1.8} viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-      </svg>
-    ),
-  },
-  {
-    href: "/items",
-    label: "Inventory",
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={1.8} viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
-      </svg>
-    ),
-  },
-  {
-    href: "/requests",
-    label: "Requests",
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={1.8} viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-      </svg>
-    ),
-  },
-  {
-    href: "/settings",
-    label: "Settings",
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={1.8} viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-        <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-      </svg>
-    ),
-  },
+  { href: "/dashboard", label: "Dashboard", icon: "dashboard" },
+  { href: "/items", label: "Inventory", icon: "inventory_2" },
+  { href: "/requests", label: "Requests", icon: "notifications" },
+  { href: "/settings", label: "Settings", icon: "settings" },
 ];
 
 export default function BottomNav() {
@@ -49,7 +16,7 @@ export default function BottomNav() {
   return (
     <nav
       aria-label="Primary"
-      className="fixed bottom-0 inset-x-0 z-50 md:hidden bg-white border-t border-gray-200 pb-[env(safe-area-inset-bottom)]"
+      className="fixed bottom-0 inset-x-0 z-50 md:hidden bg-white/60 backdrop-blur-xl rounded-t-3xl pb-[env(safe-area-inset-bottom)]"
     >
       <div className="flex">
         {navItems.map((item) => {
@@ -60,12 +27,19 @@ export default function BottomNav() {
             <Link
               key={item.href}
               href={item.href}
-              className={`flex-1 flex min-h-14 flex-col items-center justify-center gap-1 py-2 text-xs font-medium transition-colors ${
-                active ? "text-blue-600" : "text-gray-500 hover:text-gray-700"
-              }`}
+              className="flex-1 flex flex-col items-center justify-center py-2"
             >
-              {item.icon}
-              <span>{item.label}</span>
+              {active ? (
+                <div className="flex flex-col items-center gap-0.5 px-4 py-2 bg-gradient-to-br from-primary to-primary-container text-white rounded-2xl">
+                  <span className="material-symbols-outlined text-[22px] leading-none">{item.icon}</span>
+                  <span className="text-[10px] font-medium">{item.label}</span>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center gap-0.5 py-2 text-on-surface-variant">
+                  <span className="material-symbols-outlined text-[22px] leading-none">{item.icon}</span>
+                  <span className="text-[10px] font-medium">{item.label}</span>
+                </div>
+              )}
             </Link>
           );
         })}

--- a/components/layout/MobileHeader.tsx
+++ b/components/layout/MobileHeader.tsx
@@ -4,11 +4,11 @@ import { signOut } from "next-auth/react";
 
 export default function MobileHeader() {
   return (
-    <header className="sticky top-0 z-40 flex md:hidden items-center justify-between px-4 py-3 bg-white border-b border-gray-200">
-      <span className="font-bold text-gray-900 text-base">InventoryAlert</span>
+    <header className="sticky top-0 z-40 flex md:hidden items-center justify-between px-4 py-3 bg-slate-50/60 backdrop-blur-xl shadow-[0_20px_40px_rgba(25,28,30,0.06)]">
+      <span className="font-headline font-bold text-primary text-base">InventoryAlert</span>
       <button
         onClick={() => signOut({ callbackUrl: "/login" })}
-        className="text-sm text-gray-500 hover:text-gray-900 transition-colors"
+        className="text-sm text-on-surface-variant hover:text-on-surface transition-colors"
       >
         Sign out
       </button>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -5,19 +5,19 @@ import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
 
 const navItems = [
-  { href: "/dashboard", label: "Dashboard" },
-  { href: "/items", label: "Inventory" },
-  { href: "/requests", label: "Stocking Requests" },
-  { href: "/settings", label: "Settings" },
+  { href: "/dashboard", label: "Dashboard", icon: "dashboard" },
+  { href: "/items", label: "Inventory", icon: "inventory_2" },
+  { href: "/requests", label: "Stocking Requests", icon: "notifications" },
+  { href: "/settings", label: "Settings", icon: "settings" },
 ];
 
 export default function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <aside className="hidden md:flex w-56 bg-white border-r border-gray-200 flex-col min-h-screen">
-      <div className="px-5 py-5 border-b border-gray-100">
-        <span className="font-bold text-gray-900 text-lg">InventoryAlert</span>
+    <aside className="hidden md:flex w-60 bg-surface-container-lowest border-r border-outline-variant flex-col min-h-screen">
+      <div className="px-5 py-5 border-b border-outline-variant">
+        <span className="font-headline font-bold text-primary text-lg">InventoryAlert</span>
       </div>
       <nav className="flex-1 px-3 py-4 space-y-1">
         {navItems.map((item) => {
@@ -28,21 +28,22 @@ export default function Sidebar() {
             <Link
               key={item.href}
               href={item.href}
-              className={`flex items-center px-3 py-2 rounded-lg text-sm transition-colors ${
+              className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
                 active
-                  ? "bg-blue-50 text-blue-700 font-medium"
-                  : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                  ? "bg-primary-fixed text-primary font-semibold"
+                  : "text-on-surface-variant hover:bg-surface-container hover:text-on-surface"
               }`}
             >
+              <span className="material-symbols-outlined text-[20px]">{item.icon}</span>
               {item.label}
             </Link>
           );
         })}
       </nav>
-      <div className="px-3 py-4 border-t border-gray-100">
+      <div className="px-3 py-4 border-t border-outline-variant">
         <button
           onClick={() => signOut({ callbackUrl: "/login" })}
-          className="w-full text-left px-3 py-2 text-sm text-gray-500 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-colors"
+          className="w-full text-left px-3 py-2 text-sm text-on-surface-variant hover:text-on-surface hover:bg-surface-container rounded-lg transition-colors"
         >
           Sign out
         </button>

--- a/components/layout/TierBadge.tsx
+++ b/components/layout/TierBadge.tsx
@@ -2,15 +2,15 @@ import type { Tier } from "@prisma/client";
 import { TIER_LIMITS } from "@/lib/tier";
 
 const colors: Record<Tier, string> = {
-  FREE: "bg-gray-100 text-gray-600",
-  FAMILY: "bg-green-100 text-green-700",
-  ENTERPRISE: "bg-purple-100 text-purple-700",
+  FREE: "bg-surface-container-high text-on-surface-variant",
+  FAMILY: "bg-secondary-container/40 text-on-secondary-container",
+  ENTERPRISE: "bg-primary-fixed text-on-primary-fixed",
 };
 
 export default function TierBadge({ tier }: { tier: Tier }) {
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${colors[tier]}`}
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colors[tier]}`}
     >
       {TIER_LIMITS[tier].label}
     </span>

--- a/lib/validations/item.ts
+++ b/lib/validations/item.ts
@@ -6,6 +6,7 @@ export const createItemSchema = z.object({
   imageUrl: z.string().url().optional().or(z.literal("")),
   alertEmail: z.string().email("Must be a valid email address"),
   lowStockThreshold: z.number().int().min(1).max(9999).nullable().optional(),
+  alertEmailEnabled: z.boolean().optional(),
 });
 
 export const updateItemSchema = createItemSchema.partial();

--- a/prisma/migrations/20260417151606_add_alert_email_enabled/migration.sql
+++ b/prisma/migrations/20260417151606_add_alert_email_enabled/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "InventoryItem" ADD COLUMN     "alertEmailEnabled" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,6 +48,7 @@ model InventoryItem {
   description       String?
   imageUrl          String?
   alertEmail        String
+  alertEmailEnabled Boolean           @default(true)
   qrCodeId          String            @unique @default(uuid())
   userId            String
 


### PR DESCRIPTION
## Summary

- **Full UI redesign** applying the Material Design 3 system from the Stitch mockup: M3 semantic color tokens (primary/secondary/surface), Plus Jakarta Sans (headlines) + Inter (body) fonts, and Material Symbols Outlined icons replacing inline SVGs
- **Frosted glass** header and bottom nav with gradient active pill; bento hero stat card on dashboard; rounded-full buttons throughout
- **Alert email toggle** — new `alertEmailEnabled` boolean on `InventoryItem` (default `true`) lets users disable per-item alert emails without removing the address; the scan endpoint records the request but skips sending the email when disabled; ItemCard shows an "Alerts off" badge

## Changes

- `app/globals.css` — M3 `@theme` color tokens + font variables
- `app/layout.tsx` — Plus Jakarta Sans, Inter, Material Symbols link tag
- `components/layout/` — BottomNav (Material Symbols, gradient pill), Sidebar (icons, new colors), MobileHeader (frosted glass)
- `app/(dashboard)/layout.tsx` — bg token + mobile FAB
- All dashboard pages and components — M3 color tokens, font-headline on headings, rounded-full buttons
- `prisma/schema.prisma` + migration — `alertEmailEnabled Boolean @default(true)`
- `lib/validations/item.ts` — `alertEmailEnabled` added to Zod schemas
- `app/api/scan/[qrCodeId]/route.ts` — respects `alertEmailEnabled` flag
- `components/items/ItemForm.tsx` — toggle switch UI for alert emails
- `components/items/ItemCard.tsx` — "Alerts off" badge

## Test plan

- [ ] Run `npx prisma generate` then `npm run dev`
- [ ] Dashboard: verify hero gradient card, M3 fonts, frosted glass header/nav
- [ ] Items list: create an item, confirm toggle defaults ON; flip to OFF and save
- [ ] Items list: item with alerts off shows "Alerts off" badge on card
- [ ] Scan a QR code with alerts OFF → no email sent, request still logged
- [ ] Scan a QR code with alerts ON → email sent as before
- [ ] Mobile (375px): bottom nav active pill, FAB visible above nav
- [ ] Desktop: sidebar uses new colors and Material Symbols icons
- [ ] Print label still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)