### PR TITLE
Sync Stripe prices + webhook fix

### DIFF
--- a/app/(dashboard)/settings/SettingsClient.tsx
+++ b/app/(dashboard)/settings/SettingsClient.tsx
@@ -6,9 +6,10 @@ import type { Tier } from "@prisma/client";
 interface Props {
   currentTier: Tier;
   hasCustomer: boolean;
+  stripePrices: { FAMILY: string; ENTERPRISE: string };
 }
 
-export default function SettingsClient({ currentTier, hasCustomer }: Props) {
+export default function SettingsClient({ currentTier, hasCustomer, stripePrices }: Props) {
   const [loading, setLoading] = useState<string | null>(null);
   const [error, setError] = useState("");
 
@@ -57,14 +58,14 @@ export default function SettingsClient({ currentTier, hasCustomer }: Props) {
               disabled={!!loading}
               className="flex-1 bg-primary text-on-primary rounded-full border-0 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
             >
-              {loading === "FAMILY" ? "Loading…" : "Family — $9/mo"}
+              {loading === "FAMILY" ? "Loading…" : `Family — ${stripePrices.FAMILY}`}
             </button>
             <button
               onClick={() => handleUpgrade("ENTERPRISE")}
               disabled={!!loading}
               className="flex-1 bg-primary-container text-on-primary-container rounded-full border border-primary/20 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
             >
-              {loading === "ENTERPRISE" ? "Loading…" : "Enterprise — $29/mo"}
+              {loading === "ENTERPRISE" ? "Loading…" : `Enterprise — ${stripePrices.ENTERPRISE}`}
             </button>
           </div>
         </div>
@@ -77,7 +78,7 @@ export default function SettingsClient({ currentTier, hasCustomer }: Props) {
             disabled={!!loading}
             className="flex-1 bg-primary-container text-on-primary-container rounded-full border border-primary/20 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
           >
-            {loading === "ENTERPRISE" ? "Loading…" : "Upgrade to Enterprise — $29/mo"}
+            {loading === "ENTERPRISE" ? "Loading…" : `Upgrade to Enterprise — ${stripePrices.ENTERPRISE}`}
           </button>
           {hasCustomer && (
             <button

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { TIER_LIMITS } from "@/lib/tier";
+import { fetchStripePrices } from "@/lib/stripe";
 import TierBadge from "@/components/layout/TierBadge";
 import SettingsClient from "./SettingsClient";
 
@@ -8,7 +9,7 @@ export default async function SettingsPage() {
   const session = await auth();
   if (!session) return null;
 
-  const [user, itemCount] = await Promise.all([
+  const [user, itemCount, stripePrices] = await Promise.all([
     prisma.user.findUnique({
       where: { id: session.user.id },
       select: {
@@ -20,6 +21,7 @@ export default async function SettingsPage() {
       },
     }),
     prisma.inventoryItem.count({ where: { userId: session.user.id } }),
+    fetchStripePrices(),
   ]);
 
   if (!user) return null;
@@ -54,7 +56,8 @@ export default async function SettingsPage() {
 
         <div className="text-sm text-on-surface-variant space-y-1">
           <p>
-            <span className="text-outline">Price:</span> {limit.price}
+            <span className="text-outline">Price:</span>{" "}
+            {tier === "FREE" ? limit.price : stripePrices[tier]}
           </p>
           <p>
             <span className="text-outline">Item limit:</span>{" "}
@@ -92,6 +95,7 @@ export default async function SettingsPage() {
         <SettingsClient
           currentTier={tier}
           hasCustomer={!!user.stripeCustomerId}
+          stripePrices={stripePrices}
         />
       </section>
     </div>

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -62,7 +62,7 @@ export async function POST(req: NextRequest) {
             tier,
             stripeCustomerId: session.customer as string,
             stripeSubscriptionId: subscription.id,
-            stripeCurrentPeriodEnd: new Date(subscription.current_period_end * 1000),
+            stripeCurrentPeriodEnd: new Date((subscription.items.data[0]?.current_period_end ?? 0) * 1000),
           },
         });
 
@@ -99,7 +99,7 @@ export async function POST(req: NextRequest) {
           where: { id: user.id },
           data: {
             tier,
-            stripeCurrentPeriodEnd: new Date(subscription.current_period_end * 1000),
+            stripeCurrentPeriodEnd: new Date((subscription.items.data[0]?.current_period_end ?? 0) * 1000),
           },
         });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import { TIER_LIMITS } from "@/lib/tier";
+import { fetchStripePrices } from "@/lib/stripe";
 import type { Tier } from "@prisma/client";
 import Link from "next/link";
 import { redirect } from "next/navigation";
@@ -78,8 +79,14 @@ const FAQS = [
 ];
 
 export default async function HomePage() {
-  const session = await auth();
+  const [session, stripePrices] = await Promise.all([auth(), fetchStripePrices()]);
   if (session) redirect("/dashboard");
+
+  const liveTierLimits = {
+    ...TIER_LIMITS,
+    FAMILY: { ...TIER_LIMITS.FAMILY, price: stripePrices.FAMILY },
+    ENTERPRISE: { ...TIER_LIMITS.ENTERPRISE, price: stripePrices.ENTERPRISE },
+  };
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100">
@@ -201,7 +208,7 @@ export default async function HomePage() {
             </p>
             <div className="mt-10 grid gap-6 md:grid-cols-3">
               {PRICING_TIERS.map((tierDisplay) => {
-                const tier = TIER_LIMITS[tierDisplay.key];
+                const tier = liveTierLimits[tierDisplay.key];
                 const [price, period] = tier.price.split("/");
                 const itemsText =
                   tier.maxItems === Infinity

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,4 +1,5 @@
 import Stripe from "stripe";
+import { TIER_LIMITS } from "@/lib/tier";
 
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2026-02-25.clover",
@@ -8,3 +9,28 @@ export const STRIPE_PRICES = {
   FAMILY: process.env.STRIPE_PRICE_FAMILY!,
   ENTERPRISE: process.env.STRIPE_PRICE_ENTERPRISE!,
 } as const;
+
+function formatStripePrice(price: Stripe.Price): string {
+  const amount = price.unit_amount ? price.unit_amount / 100 : 0;
+  const interval = price.recurring?.interval ?? "mo";
+  const formatted = Number.isInteger(amount) ? `$${amount}` : `$${amount.toFixed(2)}`;
+  return `${formatted}/${interval}`;
+}
+
+export async function fetchStripePrices(): Promise<Record<"FAMILY" | "ENTERPRISE", string>> {
+  try {
+    const [family, enterprise] = await Promise.all([
+      stripe.prices.retrieve(STRIPE_PRICES.FAMILY),
+      stripe.prices.retrieve(STRIPE_PRICES.ENTERPRISE),
+    ]);
+    return {
+      FAMILY: formatStripePrice(family),
+      ENTERPRISE: formatStripePrice(enterprise),
+    };
+  } catch {
+    return {
+      FAMILY: TIER_LIMITS.FAMILY.price,
+      ENTERPRISE: TIER_LIMITS.ENTERPRISE.price,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Fix Stripe webhook to read `current_period_end` from the subscription item (compatible with Stripe SDK v20)
- Fetch live subscription prices from the Stripe API at render time so the landing page and settings page always reflect the current Stripe price, with graceful fallback to hardcoded values if Stripe is unreachable

## Test plan
- [ ] Verify the landing page pricing cards show prices sourced from Stripe
- [ ] Verify the Settings page upgrade buttons show prices sourced from Stripe
- [ ] Simulate a Stripe API failure and confirm the UI falls back to hardcoded values without crashing
- [ ] Trigger a test Stripe webhook event (`customer.subscription.updated`) and confirm `stripeCurrentPeriodEnd` is updated correctly in the database

https://claude.ai/code/session_011BagqrJTJ91rjQaqPTMFnE