### PR TITLE
fix: prevent item creation hang on unhandled errors (closes #36)

### DIFF
--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -17,39 +17,44 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const session = await auth();
-  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    const session = await auth();
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = await req.json();
-  const parsed = createItemSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.issues[0].message },
-      { status: 400 }
-    );
-  }
+    const body = await req.json();
+    const parsed = createItemSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
 
-  const count = await prisma.inventoryItem.count({
-    where: { userId: session.user.id },
-  });
+    const count = await prisma.inventoryItem.count({
+      where: { userId: session.user.id },
+    });
 
-  if (!canCreateItem(session.user.tier, count)) {
-    return NextResponse.json(
-      {
-        error: "Item limit reached for your current plan. Please upgrade to add more items.",
-        code: "TIER_LIMIT",
+    if (!canCreateItem(session.user.tier, count)) {
+      return NextResponse.json(
+        {
+          error: "Item limit reached for your current plan. Please upgrade to add more items.",
+          code: "TIER_LIMIT",
+        },
+        { status: 403 }
+      );
+    }
+
+    const item = await prisma.inventoryItem.create({
+      data: {
+        ...parsed.data,
+        imageUrl: parsed.data.imageUrl || null,
+        userId: session.user.id,
       },
-      { status: 403 }
-    );
+    });
+
+    return NextResponse.json(item, { status: 201 });
+  } catch (err) {
+    console.error("[POST /api/items]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-
-  const item = await prisma.inventoryItem.create({
-    data: {
-      ...parsed.data,
-      imageUrl: parsed.data.imageUrl || null,
-      userId: session.user.id,
-    },
-  });
-
-  return NextResponse.json(item, { status: 201 });
 }

--- a/components/items/ItemForm.tsx
+++ b/components/items/ItemForm.tsx
@@ -33,15 +33,20 @@ export default function ItemForm({ item, mode }: Props) {
       return;
     }
     setUploading(true);
-    const form = new FormData();
-    form.append("file", file);
-    const res = await fetch("/api/upload", { method: "POST", body: form });
-    const data = await res.json();
-    setUploading(false);
-    if (res.ok) {
-      setImageUrl(data.url);
-    } else {
-      setError(data.error || "Upload failed.");
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch("/api/upload", { method: "POST", body: form });
+      const data = await res.json();
+      setUploading(false);
+      if (res.ok) {
+        setImageUrl(data.url);
+      } else {
+        setError(data.error || "Upload failed.");
+      }
+    } catch {
+      setUploading(false);
+      setError("Upload failed. Please try again.");
     }
   }
 
@@ -49,33 +54,37 @@ export default function ItemForm({ item, mode }: Props) {
     e.preventDefault();
     setError("");
     setLoading(true);
+    try {
+      const threshold = lowStockThreshold ? parseInt(lowStockThreshold, 10) : null;
+      const payload = {
+        name,
+        description: description || undefined,
+        alertEmail,
+        imageUrl: imageUrl || undefined,
+        lowStockThreshold: threshold && !isNaN(threshold) ? threshold : null,
+        alertEmailEnabled,
+      };
 
-    const threshold = lowStockThreshold ? parseInt(lowStockThreshold, 10) : null;
-    const payload = {
-      name,
-      description: description || undefined,
-      alertEmail,
-      imageUrl: imageUrl || undefined,
-      lowStockThreshold: threshold && !isNaN(threshold) ? threshold : null,
-      alertEmailEnabled,
-    };
+      const res = await fetch(
+        mode === "create" ? "/api/items" : `/api/items/${item!.id}`,
+        {
+          method: mode === "create" ? "POST" : "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }
+      );
+      const data = await res.json();
+      setLoading(false);
 
-    const res = await fetch(
-      mode === "create" ? "/api/items" : `/api/items/${item!.id}`,
-      {
-        method: mode === "create" ? "POST" : "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+      if (!res.ok) {
+        setError(data.error || "Something went wrong.");
+      } else {
+        router.push("/items");
+        router.refresh();
       }
-    );
-    const data = await res.json();
-    setLoading(false);
-
-    if (!res.ok) {
-      setError(data.error || "Something went wrong.");
-    } else {
-      router.push("/items");
-      router.refresh();
+    } catch {
+      setLoading(false);
+      setError("An unexpected error occurred. Please try again.");
     }
   }
 


### PR DESCRIPTION
Wrap handleSubmit and handleImageChange in try-catch so setLoading(false)
always runs — previously any thrown error (e.g. res.json() failing on an
HTML error response) left the button permanently in "Creating…" state.

Wrap POST /api/items in try-catch so all server-side exceptions return
NextResponse.json() instead of Next.js's HTML error page, preventing
the SyntaxError that triggered the client-side hang.

https://claude.ai/code/session_01M8XDqEKrahhFhJYFpshkX8