### PR TITLE
Fix Stripe product default_price type guard

### DIFF
--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -26,7 +26,7 @@ function formatStripePrice(price: Stripe.Price): string {
 
 async function getDefaultPriceIdForProduct(productId: string): Promise<string | null> {
   const product = await stripe.products.retrieve(productId, { expand: ["default_price"] });
-  if (!product || product.deleted || !product.default_price) return null;
+  if (!product.default_price) return null;
 
   if (typeof product.default_price === "string") {
     return product.default_price;


### PR DESCRIPTION
### Motivation
- The Stripe `Product` type in the SDK marks `deleted` as `void` for non-deleted products, so checking `product.deleted` for truthiness caused a TypeScript `TS1345` error during build.

### Description
- Remove the invalid `product.deleted` truthiness check in `getDefaultPriceIdForProduct` in `lib/stripe.ts` and retain the existing `default_price` null-check and string/object handling logic.

### Testing
- Ran `npx tsc --noEmit` which passed after the change.
- Ran `npm run build` which now proceeds past TypeScript checks but still fails in this environment due to Google Fonts fetch/network errors unrelated to the Stripe type fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38bae66e48333a196dac6c9b9df98)