### PR TITLE
Add real-time SSE stream and push notification support for stocking requests

### DIFF
--- a/app/(dashboard)/requests/RequestsClient.tsx
+++ b/app/(dashboard)/requests/RequestsClient.tsx
@@ -14,6 +14,15 @@ interface Request {
   item: { name: string; id: string };
 }
 
+interface RealtimeEvent {
+  requestId: string;
+  itemId: string;
+  itemName: string;
+  status: RequestStatus;
+  emailSent: boolean;
+  createdAt: string;
+}
+
 interface Props {
   initialRequests: Request[];
   activeStatus: RequestStatus | null;
@@ -36,6 +45,7 @@ export default function RequestsClient({ initialRequests, activeStatus }: Props)
   const router = useRouter();
   const [requests, setRequests] = useState(initialRequests);
   const [loading, setLoading] = useState<string | null>(null);
+  const [liveStatus, setLiveStatus] = useState<"connecting" | "live" | "offline">("connecting");
 
   // Sync local state when the server sends new filtered data after navigation
   useEffect(() => {
@@ -51,6 +61,56 @@ export default function RequestsClient({ initialRequests, activeStatus }: Props)
       }
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const source = new EventSource("/api/requests/stream");
+
+    source.addEventListener("connected", () => {
+      setLiveStatus("live");
+    });
+
+    source.addEventListener("stocking-request", (event) => {
+      setLiveStatus("live");
+      const payload = JSON.parse((event as MessageEvent).data) as RealtimeEvent;
+
+      if (typeof Notification !== "undefined" && Notification.permission === "granted") {
+        new Notification("New stocking request", {
+          body: `${payload.itemName} needs attention.`,
+          tag: `stocking-request-${payload.requestId}`,
+        });
+      }
+
+      setRequests((prev) => {
+        const exists = prev.some((request) => request.id === payload.requestId);
+        if (exists) return prev;
+
+        const nextRequest: Request = {
+          id: payload.requestId,
+          status: payload.status,
+          emailSent: payload.emailSent,
+          createdAt: new Date(payload.createdAt),
+          item: {
+            id: payload.itemId,
+            name: payload.itemName,
+          },
+        };
+
+        if (activeStatus && nextRequest.status !== activeStatus) {
+          return prev;
+        }
+
+        return [nextRequest, ...prev];
+      });
+    });
+
+    source.onerror = () => {
+      setLiveStatus("offline");
+    };
+
+    return () => {
+      source.close();
+    };
+  }, [activeStatus]);
 
   function handleTabChange(status: RequestStatus | null) {
     if (status) {
@@ -81,6 +141,25 @@ export default function RequestsClient({ initialRequests, activeStatus }: Props)
 
   return (
     <div>
+      <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-outline-variant px-3 py-1 text-xs">
+        <span
+          className={`h-2 w-2 rounded-full ${
+            liveStatus === "live"
+              ? "bg-secondary"
+              : liveStatus === "connecting"
+                ? "bg-tertiary"
+                : "bg-error"
+          }`}
+        />
+        <span className="text-on-surface-variant">
+          {liveStatus === "live"
+            ? "Live updates on"
+            : liveStatus === "connecting"
+              ? "Connecting live updates…"
+              : "Live updates disconnected"}
+        </span>
+      </div>
+
       {/* Tabs */}
       <div className="overflow-x-auto mb-5">
       <div className="flex gap-1 bg-surface-container rounded-2xl p-1 w-fit">

--- a/app/(dashboard)/settings/SettingsClient.tsx
+++ b/app/(dashboard)/settings/SettingsClient.tsx
@@ -7,11 +7,31 @@ interface Props {
   currentTier: Tier;
   hasCustomer: boolean;
   stripePrices: { FAMILY: string; ENTERPRISE: string };
+  hasPushSubscription: boolean;
 }
 
-export default function SettingsClient({ currentTier, hasCustomer, stripePrices }: Props) {
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+
+  return outputArray;
+}
+
+export default function SettingsClient({
+  currentTier,
+  hasCustomer,
+  stripePrices,
+  hasPushSubscription,
+}: Props) {
   const [loading, setLoading] = useState<string | null>(null);
   const [error, setError] = useState("");
+  const [pushEnabled, setPushEnabled] = useState(hasPushSubscription);
 
   async function handleUpgrade(tier: "FAMILY" | "ENTERPRISE") {
     setError("");
@@ -43,11 +63,114 @@ export default function SettingsClient({ currentTier, hasCustomer, stripePrices 
     }
   }
 
+  async function handleEnablePush() {
+    setError("");
+    setLoading("push-enable");
+
+    try {
+      if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+        throw new Error("Your browser does not support push notifications.");
+      }
+
+      const keyRes = await fetch("/api/push/public-key", { cache: "no-store" });
+      const keyData = await keyRes.json();
+      if (!keyRes.ok || !keyData?.enabled || !keyData?.publicKey) {
+        throw new Error("Push notifications are not configured on the server.");
+      }
+
+      const permission = await Notification.requestPermission();
+      if (permission !== "granted") {
+        throw new Error("Permission denied. Please allow notifications in your browser settings.");
+      }
+
+      const registration = await navigator.serviceWorker.register("/sw.js");
+      const existing = await registration.pushManager.getSubscription();
+
+      const subscription =
+        existing ??
+        (await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: urlBase64ToUint8Array(keyData.publicKey),
+        }));
+
+      const saveRes = await fetch("/api/push/subscription", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(subscription),
+      });
+
+      if (!saveRes.ok) {
+        throw new Error("Failed to save your notification subscription.");
+      }
+
+      setPushEnabled(true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to enable notifications.";
+      setError(message);
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  async function handleDisablePush() {
+    setError("");
+    setLoading("push-disable");
+
+    try {
+      if (!("serviceWorker" in navigator)) {
+        throw new Error("Service workers are not supported in this browser.");
+      }
+
+      const registration = await navigator.serviceWorker.getRegistration("/");
+      const subscription = await registration?.pushManager.getSubscription();
+
+      if (subscription) {
+        await fetch("/api/push/subscription", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ endpoint: subscription.endpoint }),
+        });
+        await subscription.unsubscribe();
+      }
+
+      setPushEnabled(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to disable notifications.";
+      setError(message);
+    } finally {
+      setLoading(null);
+    }
+  }
+
   return (
-    <div className="space-y-3 pt-2">
+    <div className="space-y-6 pt-2">
       {error && (
         <p className="text-sm text-error">{error}</p>
       )}
+
+      <div className="rounded-xl border border-outline-variant p-4 space-y-3">
+        <h3 className="font-medium text-on-surface">Phone Notifications</h3>
+        <p className="text-sm text-on-surface-variant">
+          Enable push notifications to get alerts on your installed app when a new stocking request is created.
+        </p>
+        {pushEnabled ? (
+          <button
+            onClick={handleDisablePush}
+            disabled={!!loading}
+            className="border border-outline text-on-surface-variant rounded-full px-4 py-2 text-sm hover:bg-surface-container disabled:opacity-50 transition-colors"
+          >
+            {loading === "push-disable" ? "Disabling…" : "Disable notifications"}
+          </button>
+        ) : (
+          <button
+            onClick={handleEnablePush}
+            disabled={!!loading}
+            className="bg-primary text-on-primary rounded-full border-0 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+          >
+            {loading === "push-enable" ? "Enabling…" : "Enable notifications"}
+          </button>
+        )}
+      </div>
 
       {currentTier === "FREE" && (
         <div className="space-y-2">

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -9,7 +9,7 @@ export default async function SettingsPage() {
   const session = await auth();
   if (!session) return null;
 
-  const [user, itemCount, stripePrices] = await Promise.all([
+  const [user, itemCount, stripePrices, pushSubscriptionCount] = await Promise.all([
     prisma.user.findUnique({
       where: { id: session.user.id },
       select: {
@@ -22,6 +22,7 @@ export default async function SettingsPage() {
     }),
     prisma.inventoryItem.count({ where: { userId: session.user.id } }),
     fetchStripePrices(),
+    prisma.pushSubscription.count({ where: { userId: session.user.id } }),
   ]);
 
   if (!user) return null;
@@ -96,6 +97,7 @@ export default async function SettingsPage() {
           currentTier={tier}
           hasCustomer={!!user.stripeCustomerId}
           stripePrices={stripePrices}
+          hasPushSubscription={pushSubscriptionCount > 0}
         />
       </section>
     </div>

--- a/app/api/push/public-key/route.ts
+++ b/app/api/push/public-key/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+
+export async function GET() {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  return NextResponse.json({
+    enabled: !!publicKey,
+    publicKey: publicKey ?? null,
+  });
+}

--- a/app/api/push/subscription/route.ts
+++ b/app/api/push/subscription/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+interface PushSubscriptionBody {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = (await req.json()) as PushSubscriptionBody;
+  if (!body?.endpoint || !body?.keys?.p256dh || !body?.keys?.auth) {
+    return NextResponse.json({ error: "Invalid subscription payload" }, { status: 400 });
+  }
+
+  await prisma.pushSubscription.upsert({
+    where: { endpoint: body.endpoint },
+    update: {
+      userId: session.user.id,
+      p256dh: body.keys.p256dh,
+      auth: body.keys.auth,
+      userAgent: req.headers.get("user-agent") ?? undefined,
+    },
+    create: {
+      userId: session.user.id,
+      endpoint: body.endpoint,
+      p256dh: body.keys.p256dh,
+      auth: body.keys.auth,
+      userAgent: req.headers.get("user-agent") ?? undefined,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(req: NextRequest) {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = (await req.json()) as { endpoint?: string };
+  if (!body?.endpoint) {
+    return NextResponse.json({ error: "endpoint is required" }, { status: 400 });
+  }
+
+  await prisma.pushSubscription.deleteMany({
+    where: { endpoint: body.endpoint, userId: session.user.id },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/requests/stream/route.ts
+++ b/app/api/requests/stream/route.ts
@@ -1,0 +1,46 @@
+import { auth } from "@/lib/auth";
+import { subscribeToStockingRequests } from "@/lib/realtime";
+
+function sseMessage(event: string, data: unknown) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const encoder = new TextEncoder();
+  let unsubscribe: (() => void) | null = null;
+  let heartbeat: ReturnType<typeof setInterval> | null = null;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(sseMessage("connected", { ok: true })));
+
+      unsubscribe = subscribeToStockingRequests(session.user.id, (event) => {
+        controller.enqueue(encoder.encode(sseMessage("stocking-request", event)));
+      });
+
+      heartbeat = setInterval(() => {
+        controller.enqueue(encoder.encode(`: keep-alive ${Date.now()}\n\n`));
+      }, 25000);
+    },
+    cancel() {
+      if (heartbeat) clearInterval(heartbeat);
+      if (unsubscribe) unsubscribe();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/app/api/scan/[qrCodeId]/route.ts
+++ b/app/api/scan/[qrCodeId]/route.ts
@@ -1,8 +1,38 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { sendAlertEmail } from "@/lib/resend";
+import { publishStockingRequestEvent } from "@/lib/realtime";
+import { sendStockingPushNotification } from "@/lib/push";
 
 type Params = { params: Promise<{ qrCodeId: string }> };
+
+async function notifyStockingRequestCreated(args: {
+  userId: string;
+  itemId: string;
+  itemName: string;
+  requestId: string;
+  createdAt: Date;
+  emailSent: boolean;
+}) {
+  publishStockingRequestEvent(args.userId, {
+    requestId: args.requestId,
+    itemId: args.itemId,
+    itemName: args.itemName,
+    status: "PENDING",
+    emailSent: args.emailSent,
+    createdAt: args.createdAt.toISOString(),
+  });
+
+  try {
+    await sendStockingPushNotification({
+      userId: args.userId,
+      itemName: args.itemName,
+      requestId: args.requestId,
+    });
+  } catch (err) {
+    console.error("Failed sending stocking push notification", err);
+  }
+}
 
 export async function POST(_req: NextRequest, { params }: Params) {
   const { qrCodeId } = await params;
@@ -17,9 +47,19 @@ export async function POST(_req: NextRequest, { params }: Params) {
 
   // If alert emails are disabled for this item, record the scan but skip email
   if (item.alertEmailEnabled === false) {
-    await prisma.stockingRequest.create({
+    const request = await prisma.stockingRequest.create({
       data: { itemId: item.id, emailSent: false },
     });
+
+    void notifyStockingRequestCreated({
+      userId: item.userId,
+      itemId: item.id,
+      itemName: item.name,
+      requestId: request.id,
+      createdAt: request.createdAt,
+      emailSent: request.emailSent,
+    });
+
     return NextResponse.json({ alreadyNotified: false, itemName: item.name });
   }
 
@@ -36,9 +76,19 @@ export async function POST(_req: NextRequest, { params }: Params) {
 
   if (recentEmailSent) {
     // Rate limited — create a record but don't send email
-    await prisma.stockingRequest.create({
+    const request = await prisma.stockingRequest.create({
       data: { itemId: item.id, emailSent: false },
     });
+
+    void notifyStockingRequestCreated({
+      userId: item.userId,
+      itemId: item.id,
+      itemName: item.name,
+      requestId: request.id,
+      createdAt: request.createdAt,
+      emailSent: request.emailSent,
+    });
+
     return NextResponse.json({
       alreadyNotified: true,
       itemName: item.name,
@@ -46,8 +96,17 @@ export async function POST(_req: NextRequest, { params }: Params) {
   }
 
   // Create stocking request and send email
-  await prisma.stockingRequest.create({
+  const request = await prisma.stockingRequest.create({
     data: { itemId: item.id, emailSent: true },
+  });
+
+  void notifyStockingRequestCreated({
+    userId: item.userId,
+    itemId: item.id,
+    itemName: item.name,
+    requestId: request.id,
+    createdAt: request.createdAt,
+    emailSent: request.emailSent,
   });
 
   try {

--- a/lib/push.ts
+++ b/lib/push.ts
@@ -1,0 +1,19 @@
+import { prisma } from "@/lib/prisma";
+
+export function isPushConfigured() {
+  return false;
+}
+
+export async function sendStockingPushNotification(args: {
+  userId: string;
+  itemName: string;
+  requestId: string;
+}) {
+  const subscriptionCount = await prisma.pushSubscription.count({ where: { userId: args.userId } });
+
+  if (subscriptionCount > 0) {
+    console.info(
+      `[push disabled] would send notification for request ${args.requestId} (${args.itemName}) to user ${args.userId}`
+    );
+  }
+}

--- a/lib/realtime.ts
+++ b/lib/realtime.ts
@@ -1,0 +1,40 @@
+type StockingRequestRealtimeEvent = {
+  requestId: string;
+  itemId: string;
+  itemName: string;
+  status: "PENDING" | "APPROVED" | "DECLINED";
+  emailSent: boolean;
+  createdAt: string;
+};
+
+type Listener = (event: StockingRequestRealtimeEvent) => void;
+
+const listenersByUser = new Map<string, Set<Listener>>();
+
+export function subscribeToStockingRequests(userId: string, listener: Listener) {
+  const listeners = listenersByUser.get(userId) ?? new Set<Listener>();
+  listeners.add(listener);
+  listenersByUser.set(userId, listeners);
+
+  return () => {
+    const current = listenersByUser.get(userId);
+    if (!current) return;
+    current.delete(listener);
+    if (current.size === 0) listenersByUser.delete(userId);
+  };
+}
+
+export function publishStockingRequestEvent(userId: string, event: StockingRequestRealtimeEvent) {
+  const listeners = listenersByUser.get(userId);
+  if (!listeners || listeners.size === 0) return;
+
+  for (const listener of listeners) {
+    try {
+      listener(event);
+    } catch (err) {
+      console.error("stocking request realtime listener failed", err);
+    }
+  }
+}
+
+export type { StockingRequestRealtimeEvent };

--- a/prisma/migrations/20260418120000_add_push_subscriptions/migration.sql
+++ b/prisma/migrations/20260418120000_add_push_subscriptions/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "PushSubscription" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "p256dh" TEXT NOT NULL,
+    "auth" TEXT NOT NULL,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PushSubscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PushSubscription_endpoint_key" ON "PushSubscription"("endpoint");
+
+-- CreateIndex
+CREATE INDEX "PushSubscription_userId_idx" ON "PushSubscription"("userId");
+
+-- AddForeignKey
+ALTER TABLE "PushSubscription" ADD CONSTRAINT "PushSubscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,7 +40,25 @@ model User {
   updatedAt              DateTime        @updatedAt
 
   items                  InventoryItem[]
+  pushSubscriptions      PushSubscription[]
 }
+
+
+model PushSubscription {
+  id        String   @id @default(cuid())
+  userId    String
+  endpoint  String   @unique
+  p256dh    String
+  auth      String
+  userAgent String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+}
+
 
 model InventoryItem {
   id                String            @id @default(cuid())

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,41 @@
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+
+  let payload = {};
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: "InventoryAlert", body: event.data.text() };
+  }
+
+  const title = payload.title || "InventoryAlert";
+  const options = {
+    body: payload.body || "You have a new update.",
+    icon: "/favicon.ico",
+    badge: "/favicon.ico",
+    tag: payload.tag || "inventoryalert-notification",
+    data: {
+      url: payload.url || "/requests",
+    },
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+
+  const targetUrl = event.notification.data?.url || "/requests";
+
+  event.waitUntil(
+    clients.matchAll({ type: "window", includeUncontrolled: true }).then((windowClients) => {
+      for (const client of windowClients) {
+        if ("focus" in client) {
+          client.navigate(targetUrl);
+          return client.focus();
+        }
+      }
+      return clients.openWindow(targetUrl);
+    })
+  );
+});


### PR DESCRIPTION
### Motivation

- Deliver live updates for new stocking requests to the dashboard UI and provide opt-in push notifications to mobile/desktop clients. 
- Persist user push subscriptions in the database so the server can target notifications later. 
- Surface a live connection status in the requests UI and allow users to enable/disable push from settings.

### Description

- Added a server-sent events endpoint at `GET /api/requests/stream` and a small realtime pub/sub in `lib/realtime.ts` to broadcast stocking request events to connected clients. 
- Updated `app/(dashboard)/requests/RequestsClient.tsx` to open an `EventSource`, show a live status indicator, create browser notifications for incoming events, and prepend new requests to the UI when appropriate. 
- Extended the scan API to publish realtime events and attempt push delivery when a new `StockingRequest` is created, via `publishStockingRequestEvent` and `sendStockingPushNotification` calls. 
- Added push-related APIs: `GET /api/push/public-key` to expose the VAPID public key and `POST/DELETE /api/push/subscription` to save and remove subscriptions in the database. 
- Added a `PushSubscription` Prisma model and SQL migration `20260418120000_add_push_subscriptions/migration.sql`, plus a `public/sw.js` service worker to display notifications and handle notification clicks. 
- Added Settings UI changes in `SettingsClient.tsx` and `settings/page.tsx` to enable/disable push subscriptions from the dashboard and to show current subscription state; includes client helpers for VAPID key decoding and service worker registration. 
- Included `lib/push.ts` as a stubbed implementation that checks subscription counts and logs (placeholder for real push sending integration).

### Testing

- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3815b12f08333aa2ded4e3a95e8b7)