### PR TITLE
Handle missing Stripe configuration and PushSubscription table gracefully

### DIFF
--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -4,6 +4,7 @@ import { TIER_LIMITS } from "@/lib/tier";
 import { fetchStripePrices } from "@/lib/stripe";
 import TierBadge from "@/components/layout/TierBadge";
 import SettingsClient from "./SettingsClient";
+import { Prisma } from "@prisma/client";
 
 export default async function SettingsPage() {
   const session = await auth();
@@ -22,7 +23,18 @@ export default async function SettingsPage() {
     }),
     prisma.inventoryItem.count({ where: { userId: session.user.id } }),
     fetchStripePrices(),
-    prisma.pushSubscription.count({ where: { userId: session.user.id } }),
+    prisma.pushSubscription.count({ where: { userId: session.user.id } }).catch((error) => {
+      // Gracefully degrade if the PushSubscription table isn't available yet
+      // (e.g. database migration lag) so Settings can still render.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2021"
+      ) {
+        return 0;
+      }
+
+      throw error;
+    }),
   ]);
 
   if (!user) return null;

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { getStripePriceIds, stripe } from "@/lib/stripe";
+import { getStripeClient, getStripePriceIds, isStripeConfigured } from "@/lib/stripe";
 import { z } from "zod";
 import type { Tier } from "@prisma/client";
 
@@ -10,6 +10,10 @@ const schema = z.object({
 });
 
 export async function POST(req: NextRequest) {
+  if (!isStripeConfigured()) {
+    return NextResponse.json({ error: "Stripe is not configured." }, { status: 503 });
+  }
+
   const session = await auth();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
@@ -29,6 +33,7 @@ export async function POST(req: NextRequest) {
     select: { stripeCustomerId: true, email: true },
   });
 
+  const stripe = getStripeClient();
   const checkoutSession = await stripe.checkout.sessions.create({
     mode: "subscription",
     customer: user?.stripeCustomerId ?? undefined,

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { stripe } from "@/lib/stripe";
+import { getStripeClient, isStripeConfigured } from "@/lib/stripe";
 
 export async function POST() {
+  if (!isStripeConfigured()) {
+    return NextResponse.json({ error: "Stripe is not configured." }, { status: 503 });
+  }
+
   const session = await auth();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
@@ -20,6 +24,7 @@ export async function POST() {
   }
 
   const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+  const stripe = getStripeClient();
 
   const portalSession = await stripe.billingPortal.sessions.create({
     customer: user.stripeCustomerId,

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { STRIPE_PRICES, STRIPE_PRODUCTS, stripe } from "@/lib/stripe";
+import { STRIPE_PRICES, STRIPE_PRODUCTS, getStripeClient, isStripeConfigured } from "@/lib/stripe";
 import { prisma } from "@/lib/prisma";
 import type Stripe from "stripe";
 import type { Tier } from "@prisma/client";
@@ -16,6 +16,11 @@ function logWebhook(
 }
 
 export async function POST(req: NextRequest) {
+  if (!isStripeConfigured()) {
+    return NextResponse.json({ error: "Stripe is not configured." }, { status: 503 });
+  }
+
+  const stripe = getStripeClient();
   const body = await req.text(); // Must read raw body before any parsing
   const sig = req.headers.get("stripe-signature");
 

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,13 +1,21 @@
 import Stripe from "stripe";
 import { TIER_LIMITS } from "@/lib/tier";
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: "2026-02-25.clover",
-});
+let stripeClient: Stripe | null = null;
+
+function createStripeClient(secretKey: string): Stripe {
+  return new Stripe(secretKey, {
+    apiVersion: "2026-02-25.clover",
+  });
+}
+
+function getStripeSecretKey(): string | null {
+  return process.env.STRIPE_SECRET_KEY ?? null;
+}
 
 export const STRIPE_PRICES = {
-  FAMILY: process.env.STRIPE_PRICE_FAMILY!,
-  ENTERPRISE: process.env.STRIPE_PRICE_ENTERPRISE!,
+  FAMILY: process.env.STRIPE_PRICE_FAMILY ?? "",
+  ENTERPRISE: process.env.STRIPE_PRICE_ENTERPRISE ?? "",
 } as const;
 
 export const STRIPE_PRODUCTS = {
@@ -17,6 +25,27 @@ export const STRIPE_PRODUCTS = {
 
 type PaidTier = "FAMILY" | "ENTERPRISE";
 
+export function isStripeConfigured(): boolean {
+  return Boolean(
+    getStripeSecretKey() &&
+    STRIPE_PRICES.FAMILY &&
+    STRIPE_PRICES.ENTERPRISE
+  );
+}
+
+export function getStripeClient(): Stripe {
+  const secretKey = getStripeSecretKey();
+  if (!secretKey) {
+    throw new Error("Stripe is not configured (missing STRIPE_SECRET_KEY).");
+  }
+
+  if (!stripeClient) {
+    stripeClient = createStripeClient(secretKey);
+  }
+
+  return stripeClient;
+}
+
 function formatStripePrice(price: Stripe.Price): string {
   const amount = price.unit_amount ? price.unit_amount / 100 : 0;
   const interval = price.recurring?.interval ?? "mo";
@@ -25,6 +54,7 @@ function formatStripePrice(price: Stripe.Price): string {
 }
 
 async function getDefaultPriceIdForProduct(productId: string): Promise<string | null> {
+  const stripe = getStripeClient();
   const product = await stripe.products.retrieve(productId, { expand: ["default_price"] });
   if (!product.default_price) return null;
 
@@ -62,7 +92,15 @@ export async function getStripePriceIds(): Promise<Record<PaidTier, string>> {
 }
 
 export async function fetchStripePrices(): Promise<Record<PaidTier, string>> {
+  if (!isStripeConfigured()) {
+    return {
+      FAMILY: TIER_LIMITS.FAMILY.price,
+      ENTERPRISE: TIER_LIMITS.ENTERPRISE.price,
+    };
+  }
+
   try {
+    const stripe = getStripeClient();
     const priceIds = await getStripePriceIds();
     const [family, enterprise] = await Promise.all([
       stripe.prices.retrieve(priceIds.FAMILY),


### PR DESCRIPTION
### Motivation
- Make Stripe usage optional and robust when environment variables or products/prices are not configured so the app can run in non-paid environments.
- Prevent the Settings page from failing if the `PushSubscription` table is not present (e.g. during migration rollout).
- Improve error handling in Stripe-related API routes to return clear 503 errors when Stripe is not configured.

### Description
- Introduce a lazy Stripe client with `getStripeClient()` and a guard `isStripeConfigured()` in `lib/stripe.ts`, and change the previous `stripe` export to use these helpers.
- Make `STRIPE_PRICES` use empty-string fallbacks and update `fetchStripePrices()` to return `TIER_LIMITS` price fallbacks when Stripe is not configured or on retrieval errors, and use `getStripeClient()` internally.
- Update API routes under `app/api/stripe/*` (`checkout`, `portal`, `webhook`) to check `isStripeConfigured()` and return `503` when Stripe isn’t available, and to use `getStripeClient()` for Stripe operations.
- Add Prisma error handling in `app/(dashboard)/settings/page.tsx` to catch `PrismaClientKnownRequestError` with code `P2021` when counting `pushSubscription` rows and return `0` so the Settings page can still render; also import `Prisma` type for the check.

### Testing
- Ran TypeScript type checking with `tsc --noEmit`, which completed successfully. 
- Performed a development build with `next build`, which completed successfully. 
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3dbe475308333940de9a51d0adbaf)