### PR TITLE
Add isPrintTarget prop to PrintLabel component

### DIFF
--- a/app/(dashboard)/items/[itemId]/print/PrintPageClient.tsx
+++ b/app/(dashboard)/items/[itemId]/print/PrintPageClient.tsx
@@ -103,7 +103,7 @@ export default function PrintPageClient({
 
       {/* Print-only view */}
       <div className="hidden print:block">
-        <PrintLabel qrCodeId={qrCodeId} size={size} elements={elements} />
+        <PrintLabel qrCodeId={qrCodeId} size={size} elements={elements} isPrintTarget />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
Added the `isPrintTarget` prop to the `PrintLabel` component when rendering in the print-only view section of the print page.

## Key Changes
- Passed `isPrintTarget={true}` prop to the `PrintLabel` component in the print-only div
- This prop allows the PrintLabel component to identify when it's being rendered as the actual print target, enabling print-specific behavior or styling

## Implementation Details
The change is minimal and focused, adding a single boolean prop to indicate that the PrintLabel is rendering in a print context. This enables the component to differentiate between preview and actual print rendering scenarios.

https://claude.ai/code/session_01ARxdUQExv9ZoFtpiErxZQc