### PR TITLE
Add border styling to absolute positioned element

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -94,5 +94,6 @@ body {
     position: absolute;
     top: 0;
     left: 0;
+    border: 1px solid black !important;
   }
 }


### PR DESCRIPTION
## Summary
Added a 1px solid black border to an absolutely positioned element within a media query breakpoint.

## Changes
- Added `border: 1px solid black !important;` to the absolute positioned element styling
- Used `!important` flag to ensure the border style takes precedence over other CSS rules

## Implementation Details
This change applies a visible border outline to an element that uses `position: absolute` with `top: 0` and `left: 0` positioning. The `!important` declaration suggests this may be overriding existing styles or ensuring the border is visible in specific contexts.

https://claude.ai/code/session_01NomTB8C36swUdYyxfJUprp