### PR TITLE
feat: add push notifications via web-push (VAPID)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,6 +36,7 @@
 | Email | Resend | ^6.9.4 |
 | File Storage | Vercel Blob | ^2.3.1 |
 | QR Code | qrcode | ^1.5.4 |
+| Push Notifications | web-push (VAPID) | ^3.x |
 
 > **Note:** This project uses **Next.js 16** with the App Router — APIs, conventions, and file structure may differ from older Next.js versions. Always read `node_modules/next/dist/docs/` before writing new Next.js code.
 
@@ -71,7 +72,11 @@
 │   │   │   └── [itemId]/route.ts # PATCH, DELETE /api/items/:id
 │   │   ├── requests/
 │   │   │   ├── route.ts          # GET /api/requests
-│   │   │   └── [requestId]/route.ts  # PATCH /api/requests/:id
+│   │   │   ├── [requestId]/route.ts  # PATCH /api/requests/:id
+│   │   │   └── stream/route.ts   # GET /api/requests/stream (SSE, authenticated)
+│   │   ├── push/
+│   │   │   ├── public-key/route.ts   # GET /api/push/public-key
+│   │   │   └── subscription/route.ts # POST / DELETE /api/push/subscription
 │   │   ├── scan/
 │   │   │   └── [qrCodeId]/route.ts   # POST /api/scan/:qrCodeId (public)
 │   │   ├── stripe/
@@ -93,6 +98,7 @@
 │   │   ├── MobileHeader.tsx
 │   │   ├── BottomNav.tsx
 │   │   └── TierBadge.tsx
+│   ├── InstallBanner.tsx         # PWA install prompt (OS-aware, one-time dismissible)
 │   └── print/
 │       ├── LabelEditor.tsx       # Interactive drag-and-drop label canvas (FAMILY/ENTERPRISE)
 │       └── PrintLabel.tsx        # Print-only renderer — accepts TextElement[] with % positions
@@ -101,15 +107,19 @@
 │   ├── prisma.ts                 # Prisma client singleton
 │   ├── stripe.ts                 # Stripe client
 │   ├── resend.ts                 # Resend email client + sendAlertEmail() + sendPasswordResetEmail()
+│   ├── push.ts                   # sendStockingPushNotification() via web-push (VAPID)
+│   ├── realtime.ts               # In-memory pub/sub for SSE stocking request events
 │   ├── tier.ts                   # TIER_LIMITS, canCreateItem()
 │   ├── label.ts                  # LABEL_SIZES, LABEL_SIZE_CONFIG, TextElement, getDefaultTextElements()
 │   └── validations/
 │       ├── item.ts               # createItemSchema, updateItemSchema
 │       └── request.ts            # updateRequestStatusSchema
 ├── prisma/
-│   ├── schema.prisma             # DB schema: User, InventoryItem, StockingRequest
+│   ├── schema.prisma             # DB schema: User, InventoryItem, StockingRequest, PushSubscription
 │   └── migrations/               # Prisma migration history
-├── public/                       # Static assets
+├── public/
+│   ├── manifest.json             # PWA manifest (required for iOS web push)
+│   └── sw.js                     # Service worker: handles push events + notification clicks
 ├── .claude/
 │   └── CLAUDE.md                 # ← This file
 ├── .mcp.json.example             # MCP server config template

--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,9 @@ STRIPE_PRODUCT_ENTERPRISE="prod_..."
 
 # Vercel Blob
 BLOB_READ_WRITE_TOKEN="vercel_blob_..."
+
+# Web Push (VAPID) — required for phone push notifications
+# Generate a keypair once with: npx web-push generate-vapid-keys
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=""
+VAPID_PRIVATE_KEY=""
+VAPID_SUBJECT="mailto:you@example.com"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,6 +30,8 @@ export default function RootLayout({
       className={`${plusJakartaSans.variable} ${inter.variable} h-full antialiased`}
     >
       <head>
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#6750A4" />
         <link
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"

--- a/lib/push.ts
+++ b/lib/push.ts
@@ -1,7 +1,25 @@
+import webpush from "web-push";
 import { prisma } from "@/lib/prisma";
 
 export function isPushConfigured() {
-  return false;
+  return !!(
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY &&
+    process.env.VAPID_PRIVATE_KEY &&
+    process.env.VAPID_SUBJECT
+  );
+}
+
+let vapidSet = false;
+function getWebPush() {
+  if (!vapidSet) {
+    webpush.setVapidDetails(
+      process.env.VAPID_SUBJECT!,
+      process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
+      process.env.VAPID_PRIVATE_KEY!
+    );
+    vapidSet = true;
+  }
+  return webpush;
 }
 
 export async function sendStockingPushNotification(args: {
@@ -9,11 +27,37 @@ export async function sendStockingPushNotification(args: {
   itemName: string;
   requestId: string;
 }) {
-  const subscriptionCount = await prisma.pushSubscription.count({ where: { userId: args.userId } });
+  if (!isPushConfigured()) return;
 
-  if (subscriptionCount > 0) {
-    console.info(
-      `[push disabled] would send notification for request ${args.requestId} (${args.itemName}) to user ${args.userId}`
-    );
-  }
+  const subscriptions = await prisma.pushSubscription.findMany({
+    where: { userId: args.userId },
+  });
+
+  if (subscriptions.length === 0) return;
+
+  const wp = getWebPush();
+  const payload = JSON.stringify({
+    title: "New stocking request",
+    body: `${args.itemName} needs attention.`,
+    tag: `stocking-${args.requestId}`,
+    url: "/requests",
+  });
+
+  await Promise.all(
+    subscriptions.map(async (sub) => {
+      try {
+        await wp.sendNotification(
+          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+          payload
+        );
+      } catch (err) {
+        const status = (err as { statusCode?: number }).statusCode;
+        if (status === 404 || status === 410) {
+          await prisma.pushSubscription.delete({ where: { endpoint: sub.endpoint } });
+        } else {
+          console.error("Push send failed for endpoint", sub.endpoint, err);
+        }
+      }
+    })
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "19.2.4",
         "resend": "^6.9.4",
         "stripe": "^20.4.1",
+        "web-push": "^3.6.7",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -32,6 +33,7 @@
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/web-push": "^3.6.4",
         "dotenv": "^17.4.0",
         "tailwindcss": "^4",
         "typescript": "^5"
@@ -1418,6 +1420,16 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vercel/blob": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.1.tgz",
@@ -1432,6 +1444,15 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
@@ -1456,6 +1477,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/async-retry": {
@@ -1496,6 +1529,18 @@
       "bin": {
         "bcrypt": "bin/bcrypt"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/c12": {
       "version": "3.1.0",
@@ -1674,6 +1719,23 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -1740,6 +1802,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/effect": {
@@ -1912,11 +1983,33 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-status-codes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
       "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -1933,6 +2026,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-buffer": {
       "version": "2.0.5",
@@ -2000,6 +2099,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lightningcss": {
@@ -2320,6 +2440,27 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/mysql2": {
       "version": "3.15.3",
@@ -3036,6 +3177,26 @@
         "node": ">= 4"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3371,6 +3532,25 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "19.2.4",
     "resend": "^6.9.4",
     "stripe": "^20.4.1",
+    "web-push": "^3.6.7",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -34,6 +35,7 @@
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "dotenv": "^17.4.0",
     "tailwindcss": "^4",
     "typescript": "^5"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "InventoryAlert",
+  "short_name": "InvAlert",
+  "description": "QR-based inventory alert system",
+  "start_url": "/dashboard",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#6750A4",
+  "icons": [
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Implements real push notifications using `web-push` (VAPID) so users receive browser/PWA notifications when a stocking request is created
- Adds `PushSubscription` model to Prisma schema with migration; stores endpoint, `p256dh`, and `auth` keys per user
- Adds `/api/push/public-key` and `/api/push/subscription` endpoints for client subscription management
- Adds `sendStockingPushNotification()` in `lib/push.ts`, called from the scan handler alongside the existing email alert
- Gracefully degrades in Settings page if the `PushSubscription` table is unavailable (migration lag)

## Test plan

- [ ] Subscribe to push notifications in Settings and verify the subscription is saved
- [ ] Scan a QR code and confirm a push notification is received in the browser/PWA
- [ ] Unsubscribe and confirm no further notifications are sent
- [ ] Verify Settings page loads correctly even before migration is applied (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)