### PR TITLE
Simplify pricing model: consolidate FAMILY and ENTERPRISE into PRO tier

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,12 +7,12 @@
 
 ## What the App Does
 
-**InventoryAlert** is a subscription-based SaaS inventory management system. Users register inventory items, each of which receives a unique QR code that can be printed as a physical label. When a QR code is scanned, the system sends a low-stock alert email to the configured address and records a `StockingRequest` in the database. A tiered subscription model (FREE / FAMILY / ENTERPRISE) enforces item limits and feature access, backed by Stripe for payment processing.
+**InventoryAlert** is a subscription-based SaaS inventory management system. Users register inventory items, each of which receives a unique QR code that can be printed as a physical label. When a QR code is scanned, the system sends a low-stock alert email to the configured address and records a `StockingRequest` in the database. A two-tier subscription model (FREE / PRO) enforces item limits and feature access, backed by Stripe for payment processing.
 
 **Core user flows:**
 1. Register / log in (email + password)
 2. Create inventory items with optional image, description, and low-stock threshold
-3. Print QR code labels (3 sizes: 3"×1", 2"×1", 1"×1") with a drag-and-drop text editor — FAMILY/ENTERPRISE only for editing/repositioning fields
+3. Print QR code labels (3 sizes: 3"×1", 2"×1", 1"×1") with a drag-and-drop text editor — PRO only for editing/repositioning fields
 4. Share QR code with staff — scanning triggers email alert + stocking request creation
 5. Review and approve/decline stocking requests in the dashboard
 6. Manage subscription via Stripe portal
@@ -100,7 +100,7 @@
 │   │   └── TierBadge.tsx
 │   ├── InstallBanner.tsx         # PWA install prompt (OS-aware, one-time dismissible)
 │   └── print/
-│       ├── LabelEditor.tsx       # Interactive drag-and-drop label canvas (FAMILY/ENTERPRISE)
+│       ├── LabelEditor.tsx       # Interactive drag-and-drop label canvas (PRO only)
 │       └── PrintLabel.tsx        # Print-only renderer — accepts TextElement[] with % positions
 ├── lib/
 │   ├── auth.ts                   # NextAuth config (Credentials provider, JWT)
@@ -289,7 +289,6 @@ The current `README.md` is the default Next.js template with `Lets go` appended.
 | 3 | Third-party cart integration | Schema fields exist (`externalCartLink`, `externalPlatform`, `externalApiKeyRef`) but feature not implemented | Medium |
 | 4 | Email error handling | `sendAlertEmail` errors are caught and logged (`console.error`) but the scan response still returns 200 — user gets no indication email failed | Medium |
 | 7 | Request notifications | No real-time notifications for new stocking requests (polling or websocket) | Low |
-| 10 | ENTERPRISE tier features | ENTERPRISE tier exists in the schema and pricing but has no differentiating features beyond FAMILY | Low |
 
 ---
 

--- a/.env.example
+++ b/.env.example
@@ -16,11 +16,9 @@ RESEND_FROM_EMAIL="alerts@yourdomain.com"
 STRIPE_SECRET_KEY="sk_test_..."
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_..."
 STRIPE_WEBHOOK_SECRET="whsec_..."
-STRIPE_PRICE_FAMILY="price_..."
-STRIPE_PRICE_ENTERPRISE="price_..."
-# Optional: use Stripe Product IDs so checkout/pricing always follow each product's default price
-STRIPE_PRODUCT_FAMILY="prod_..."
-STRIPE_PRODUCT_ENTERPRISE="prod_..."
+STRIPE_PRICE_PRO="price_..."
+# Optional: use Stripe Product ID so checkout/pricing always follow the product's default price
+STRIPE_PRODUCT_PRO="prod_..."
 
 # Vercel Blob
 BLOB_READ_WRITE_TOKEN="vercel_blob_..."

--- a/app/(dashboard)/settings/SettingsClient.tsx
+++ b/app/(dashboard)/settings/SettingsClient.tsx
@@ -6,7 +6,7 @@ import type { Tier } from "@prisma/client";
 interface Props {
   currentTier: Tier;
   hasCustomer: boolean;
-  stripePrices: { FAMILY: string; ENTERPRISE: string };
+  stripePrices: { PRO: string };
   hasPushSubscription: boolean;
 }
 
@@ -33,7 +33,7 @@ export default function SettingsClient({
   const [error, setError] = useState("");
   const [pushEnabled, setPushEnabled] = useState(hasPushSubscription);
 
-  async function handleUpgrade(tier: "FAMILY" | "ENTERPRISE") {
+  async function handleUpgrade(tier: "PRO") {
     setError("");
     setLoading(tier);
     const res = await fetch("/api/stripe/checkout", {
@@ -175,53 +175,23 @@ export default function SettingsClient({
       {currentTier === "FREE" && (
         <div className="space-y-2">
           <p className="text-sm text-on-surface-variant font-medium">Upgrade your plan</p>
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <button
-              onClick={() => handleUpgrade("FAMILY")}
-              disabled={!!loading}
-              className="flex-1 bg-primary text-on-primary rounded-full border-0 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
-            >
-              {loading === "FAMILY" ? "Loading…" : `Family — ${stripePrices.FAMILY}`}
-            </button>
-            <button
-              onClick={() => handleUpgrade("ENTERPRISE")}
-              disabled={!!loading}
-              className="flex-1 bg-primary-container text-on-primary-container rounded-full border border-primary/20 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
-            >
-              {loading === "ENTERPRISE" ? "Loading…" : `Enterprise — ${stripePrices.ENTERPRISE}`}
-            </button>
-          </div>
-        </div>
-      )}
-
-      {currentTier === "FAMILY" && (
-        <div className="flex flex-col gap-2 sm:flex-row">
           <button
-            onClick={() => handleUpgrade("ENTERPRISE")}
+            onClick={() => handleUpgrade("PRO")}
             disabled={!!loading}
-            className="flex-1 bg-primary-container text-on-primary-container rounded-full border border-primary/20 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+            className="w-full bg-primary text-on-primary rounded-full border-0 px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
           >
-            {loading === "ENTERPRISE" ? "Loading…" : `Upgrade to Enterprise — ${stripePrices.ENTERPRISE}`}
+            {loading === "PRO" ? "Loading…" : `Upgrade to Pro — ${stripePrices.PRO}`}
           </button>
-          {hasCustomer && (
-            <button
-              onClick={handlePortal}
-              disabled={!!loading}
-              className="sm:w-auto border border-outline text-on-surface-variant rounded-full px-4 py-2 text-sm hover:bg-surface-container disabled:opacity-50 transition-colors"
-            >
-              {loading === "portal" ? "Loading…" : "Edit / Cancel"}
-            </button>
-          )}
         </div>
       )}
 
-      {currentTier === "ENTERPRISE" && hasCustomer && (
+      {currentTier === "PRO" && hasCustomer && (
         <button
           onClick={handlePortal}
           disabled={!!loading}
           className="border border-outline text-on-surface-variant rounded-full px-4 py-2 text-sm hover:bg-surface-container disabled:opacity-50 transition-colors"
         >
-          {loading === "portal" ? "Loading…" : "Edit / Cancel"}
+          {loading === "portal" ? "Loading…" : "Manage subscription"}
         </button>
       )}
     </div>

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import type { Tier } from "@prisma/client";
 
 const schema = z.object({
-  tier: z.enum(["FAMILY", "ENTERPRISE"]),
+  tier: z.enum(["PRO"]),
 });
 
 export async function POST(req: NextRequest) {
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid tier" }, { status: 400 });
   }
 
-  const tier = parsed.data.tier as Exclude<Tier, "FREE">;
+  const tier = parsed.data.tier as "PRO";
   const priceIds = await getStripePriceIds();
   const priceId = priceIds[tier];
   const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -101,15 +101,10 @@ export async function POST(req: NextRequest) {
 
         let tier: Tier = "FREE";
         if (
-          (STRIPE_PRODUCTS.FAMILY && productId === STRIPE_PRODUCTS.FAMILY) ||
-          (!STRIPE_PRODUCTS.FAMILY && priceId === STRIPE_PRICES.FAMILY)
+          (STRIPE_PRODUCTS.PRO && productId === STRIPE_PRODUCTS.PRO) ||
+          (!STRIPE_PRODUCTS.PRO && priceId === STRIPE_PRICES.PRO)
         ) {
-          tier = "FAMILY";
-        } else if (
-          (STRIPE_PRODUCTS.ENTERPRISE && productId === STRIPE_PRODUCTS.ENTERPRISE) ||
-          (!STRIPE_PRODUCTS.ENTERPRISE && priceId === STRIPE_PRICES.ENTERPRISE)
-        ) {
-          tier = "ENTERPRISE";
+          tier = "PRO";
         }
 
         await prisma.user.update({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,17 +22,11 @@ const PRICING_TIERS: TierDisplay[] = [
     highlight: false,
   },
   {
-    key: "FAMILY",
-    description: "For growing operations that need unlimited inventory and faster response loops.",
-    cta: "Choose Family",
+    key: "PRO",
+    description: "Unlimited inventory, custom label workflows, and priority support.",
+    cta: "Get Pro",
     highlight: true,
-    badge: "Best value",
-  },
-  {
-    key: "ENTERPRISE",
-    description: "For multi-location teams that need branded workflows and advanced control.",
-    cta: "Talk to sales",
-    highlight: false,
+    badge: "Most popular",
   },
 ];
 
@@ -84,8 +78,7 @@ export default async function HomePage() {
 
   const liveTierLimits = {
     ...TIER_LIMITS,
-    FAMILY: { ...TIER_LIMITS.FAMILY, price: stripePrices.FAMILY },
-    ENTERPRISE: { ...TIER_LIMITS.ENTERPRISE, price: stripePrices.ENTERPRISE },
+    PRO: { ...TIER_LIMITS.PRO, price: stripePrices.PRO },
   };
 
   return (
@@ -206,7 +199,7 @@ export default async function HomePage() {
             <p className="scroll-reveal mx-auto mt-3 max-w-2xl text-center text-slate-300">
               Start free, grow as needed, and keep predictable costs as your operations expand.
             </p>
-            <div className="mt-10 grid gap-6 md:grid-cols-3">
+            <div className="mt-10 grid gap-6 md:grid-cols-2">
               {PRICING_TIERS.map((tierDisplay) => {
                 const tier = liveTierLimits[tierDisplay.key];
                 const [price, period] = tier.price.split("/");
@@ -230,7 +223,7 @@ export default async function HomePage() {
                       "QR label generation",
                       "Instant email alerts",
                       "Request tracking dashboard",
-                      tier.customLabels ? "Custom labels" : "Custom labels (Enterprise only)",
+                      tier.customLabels ? "Custom labels" : "Custom labels (Pro only)",
                     ]}
                   />
                 );

--- a/components/layout/TierBadge.tsx
+++ b/components/layout/TierBadge.tsx
@@ -3,8 +3,7 @@ import { TIER_LIMITS } from "@/lib/tier";
 
 const colors: Record<Tier, string> = {
   FREE: "bg-surface-container-high text-on-surface-variant",
-  FAMILY: "bg-secondary-container/40 text-on-secondary-container",
-  ENTERPRISE: "bg-primary-fixed text-on-primary-fixed",
+  PRO: "bg-primary-fixed text-on-primary-fixed",
 };
 
 export default function TierBadge({ tier }: { tier: Tier }) {

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -14,22 +14,19 @@ function getStripeSecretKey(): string | null {
 }
 
 export const STRIPE_PRICES = {
-  FAMILY: process.env.STRIPE_PRICE_FAMILY ?? "",
-  ENTERPRISE: process.env.STRIPE_PRICE_ENTERPRISE ?? "",
+  PRO: process.env.STRIPE_PRICE_PRO ?? "",
 } as const;
 
 export const STRIPE_PRODUCTS = {
-  FAMILY: process.env.STRIPE_PRODUCT_FAMILY,
-  ENTERPRISE: process.env.STRIPE_PRODUCT_ENTERPRISE,
+  PRO: process.env.STRIPE_PRODUCT_PRO,
 } as const;
 
-type PaidTier = "FAMILY" | "ENTERPRISE";
+type PaidTier = "PRO";
 
 export function isStripeConfigured(): boolean {
   return Boolean(
     getStripeSecretKey() &&
-    STRIPE_PRICES.FAMILY &&
-    STRIPE_PRICES.ENTERPRISE
+    STRIPE_PRICES.PRO
   );
 }
 
@@ -66,10 +63,9 @@ async function getDefaultPriceIdForProduct(productId: string): Promise<string | 
 }
 
 export async function getStripePriceIds(): Promise<Record<PaidTier, string>> {
-  const tiers: PaidTier[] = ["FAMILY", "ENTERPRISE"];
+  const tiers: PaidTier[] = ["PRO"];
   const fallback: Record<PaidTier, string> = {
-    FAMILY: STRIPE_PRICES.FAMILY,
-    ENTERPRISE: STRIPE_PRICES.ENTERPRISE,
+    PRO: STRIPE_PRICES.PRO,
   };
 
   const resolved = await Promise.all(
@@ -94,27 +90,21 @@ export async function getStripePriceIds(): Promise<Record<PaidTier, string>> {
 export async function fetchStripePrices(): Promise<Record<PaidTier, string>> {
   if (!isStripeConfigured()) {
     return {
-      FAMILY: TIER_LIMITS.FAMILY.price,
-      ENTERPRISE: TIER_LIMITS.ENTERPRISE.price,
+      PRO: TIER_LIMITS.PRO.price,
     };
   }
 
   try {
     const stripe = getStripeClient();
     const priceIds = await getStripePriceIds();
-    const [family, enterprise] = await Promise.all([
-      stripe.prices.retrieve(priceIds.FAMILY),
-      stripe.prices.retrieve(priceIds.ENTERPRISE),
-    ]);
+    const pro = await stripe.prices.retrieve(priceIds.PRO);
 
     return {
-      FAMILY: formatStripePrice(family),
-      ENTERPRISE: formatStripePrice(enterprise),
+      PRO: formatStripePrice(pro),
     };
   } catch {
     return {
-      FAMILY: TIER_LIMITS.FAMILY.price,
-      ENTERPRISE: TIER_LIMITS.ENTERPRISE.price,
+      PRO: TIER_LIMITS.PRO.price,
     };
   }
 }

--- a/lib/tier.ts
+++ b/lib/tier.ts
@@ -10,16 +10,10 @@ export const TIER_LIMITS: Record<
     label: "Free",
     price: "$0/mo",
   },
-  FAMILY: {
+  PRO: {
     maxItems: Infinity,
     customLabels: true,
-    label: "Family",
-    price: "$9/mo",
-  },
-  ENTERPRISE: {
-    maxItems: Infinity,
-    customLabels: true,
-    label: "Enterprise",
+    label: "Pro",
     price: "$29/mo",
   },
 };

--- a/prisma/migrations/20260418200000_refactor_pricing_tiers/migration.sql
+++ b/prisma/migrations/20260418200000_refactor_pricing_tiers/migration.sql
@@ -1,0 +1,17 @@
+-- Add PRO value to the existing Tier enum
+ALTER TYPE "Tier" ADD VALUE IF NOT EXISTS 'PRO';
+
+-- Migrate existing paid users to PRO
+UPDATE "User" SET "tier" = 'PRO' WHERE "tier" IN ('FAMILY', 'ENTERPRISE');
+
+-- Recreate the Tier enum with only FREE and PRO, then swap it in
+-- PostgreSQL does not support DROP VALUE on enums, so we rename the old type,
+-- create the new one, re-cast the column, then drop the old type.
+ALTER TYPE "Tier" RENAME TO "Tier_old";
+
+CREATE TYPE "Tier" AS ENUM ('FREE', 'PRO');
+
+ALTER TABLE "User" ALTER COLUMN "tier" TYPE "Tier" USING "tier"::text::"Tier";
+ALTER TABLE "User" ALTER COLUMN "tier" SET DEFAULT 'FREE';
+
+DROP TYPE "Tier_old";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,8 +8,7 @@ datasource db {
 
 enum Tier {
   FREE
-  FAMILY
-  ENTERPRISE
+  PRO
 }
 
 enum RequestStatus {


### PR DESCRIPTION
## Summary
This PR consolidates the three-tier pricing model (FREE / FAMILY / ENTERPRISE) into a simpler two-tier model (FREE / PRO). All paid features and pricing are unified under a single "Pro" tier at $29/mo.

## Key Changes

- **Pricing Tier Consolidation**: Removed FAMILY ($9/mo) and ENTERPRISE tiers, replacing them with a single PRO tier ($29/mo) that includes all paid features (unlimited inventory, custom labels)
- **Database Migration**: Added Prisma migration to update the `Tier` enum, migrating all existing FAMILY and ENTERPRISE users to PRO
- **Stripe Configuration**: Updated environment variables and Stripe integration to reference only `STRIPE_PRICE_PRO` and `STRIPE_PRODUCT_PRO`
- **UI Updates**: 
  - Simplified pricing page from 3-column to 2-column grid layout
  - Removed FAMILY upgrade button and FAMILY→ENTERPRISE upgrade path
  - Updated CTA text from "Choose Family" / "Talk to sales" to "Get Pro"
  - Changed badge from "Best value" to "Most popular"
  - Updated subscription management button text to "Manage subscription"
- **Type Safety**: Updated TypeScript types throughout to reflect the single paid tier (`PaidTier = "PRO"`)
- **Documentation**: Updated CLAUDE.md and .env.example to reflect the new pricing structure

## Implementation Details

- The Prisma migration uses PostgreSQL enum type recreation to safely remove the old enum values while preserving data integrity
- All Stripe webhook logic updated to map to the single PRO tier
- Settings page now shows a single upgrade button for FREE users and a subscription management button for PRO users
- Tier limits configuration simplified to only define FREE and PRO tiers

https://claude.ai/code/session_01RPNEGccp6R1trVzeshQgEr