### PR TITLE
Add Terms of Service, Privacy Policy, and T&C acknowledgment at registration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -86,6 +86,8 @@
 │   │   └── upload/route.ts           # POST /api/upload
 │   ├── scan/
 │   │   └── [qrCodeId]/page.tsx       # Public QR scan landing page
+│   ├── terms/page.tsx                # Public Terms of Service page
+│   ├── privacy/page.tsx              # Public Privacy Policy page
 │   ├── page.tsx                      # Public marketing / landing page
 │   └── layout.tsx                    # Root layout (fonts, metadata)
 ├── components/
@@ -239,7 +241,8 @@ await sendAlertEmail({ itemName, alertEmail });
 ## Database Schema Summary
 
 ```
-User            — id, email, hashedPassword, name, tier, stripeCustomerId, stripeSubscriptionId
+User            — id, email, hashedPassword, name, tier, stripeCustomerId, stripeSubscriptionId,
+                  termsAcceptedAt, termsVersion
 InventoryItem   — id, name, description, imageUrl, alertEmail, qrCodeId (UUID), userId, lowStockThreshold
                   + future fields: externalCartLink, externalPlatform, externalApiKeyRef
 StockingRequest — id, itemId, status (PENDING/APPROVED/DECLINED), emailSent, createdAt

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ STRIPE_PRODUCT_PRO="prod_..."
 # Vercel Blob
 BLOB_READ_WRITE_TOKEN="vercel_blob_..."
 
+# Legal / compliance (used in Terms of Service and Privacy Policy pages)
+LEGAL_CONTACT_EMAIL="chris.cremeens@petra413.com"
+LEGAL_COMPANY_ADDRESS="1586 Spruce Dr., Arkdale WI 54613"
+
 # Web Push (VAPID) — required for phone push notifications
 # Generate a keypair once with: npx web-push generate-vapid-keys
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=""

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -9,6 +9,7 @@ export default function RegisterPage() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [termsAccepted, setTermsAccepted] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -19,7 +20,7 @@ export default function RegisterPage() {
     const res = await fetch("/api/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, email, password }),
+      body: JSON.stringify({ name, email, password, termsAccepted }),
     });
     const data = await res.json();
     setLoading(false);
@@ -80,9 +81,28 @@ export default function RegisterPage() {
             />
             <p className="text-xs text-gray-400 mt-1">Minimum 8 characters</p>
           </div>
+          <div className="flex items-start gap-3">
+            <input
+              id="terms"
+              type="checkbox"
+              checked={termsAccepted}
+              onChange={(e) => setTermsAccepted(e.target.checked)}
+              className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer rounded border-gray-300 accent-blue-600"
+            />
+            <label htmlFor="terms" className="text-sm text-gray-600 leading-5">
+              I agree to the{" "}
+              <Link href="/terms" target="_blank" className="text-blue-600 hover:underline">
+                Terms of Service
+              </Link>{" "}
+              and{" "}
+              <Link href="/privacy" target="_blank" className="text-blue-600 hover:underline">
+                Privacy Policy
+              </Link>
+            </label>
+          </div>
           <button
             type="submit"
-            disabled={loading}
+            disabled={loading || !termsAccepted}
             className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
           >
             {loading ? "Creating account…" : "Create account"}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -9,9 +9,7 @@ const schema = z.object({
   name: z.string().max(100).optional(),
   email: z.string().email(),
   password: z.string().min(8),
-  termsAccepted: z.literal(true, {
-    errorMap: () => ({ message: "You must accept the Terms of Service to register." }),
-  }),
+  termsAccepted: z.literal(true, { message: "You must accept the Terms of Service to register." }),
 });
 
 export async function POST(req: NextRequest) {

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -3,10 +3,15 @@ import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
 import { z } from "zod";
 
+const TERMS_VERSION = "2026-04-18";
+
 const schema = z.object({
   name: z.string().max(100).optional(),
   email: z.string().email(),
   password: z.string().min(8),
+  termsAccepted: z.literal(true, {
+    errorMap: () => ({ message: "You must accept the Terms of Service to register." }),
+  }),
 });
 
 export async function POST(req: NextRequest) {
@@ -32,7 +37,7 @@ export async function POST(req: NextRequest) {
 
     const hashedPassword = await bcrypt.hash(password, 12);
     await prisma.user.create({
-      data: { email, hashedPassword, name },
+      data: { email, hashedPassword, name, termsAcceptedAt: new Date(), termsVersion: TERMS_VERSION },
     });
 
     return NextResponse.json({ ok: true }, { status: 201 });

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -42,6 +42,12 @@ export async function POST(req: NextRequest) {
     success_url: `${baseUrl}/settings?upgraded=1`,
     cancel_url: `${baseUrl}/settings`,
     metadata: { userId: session.user.id, tier },
+    consent_collection: { terms_of_service: "required" },
+    custom_text: {
+      terms_of_service_acceptance: {
+        message: `I agree to the InventoryAlert [Terms of Service](${baseUrl}/terms).`,
+      },
+    },
   });
 
   return NextResponse.json({ url: checkoutSession.url });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -251,6 +251,12 @@ export default async function HomePage() {
         <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-4 px-6 py-8 text-sm text-slate-300 sm:flex-row">
           <p>InventoryAlert · Stock alerts without workflow friction.</p>
           <div className="flex gap-4">
+            <Link href="/terms" className="hover:text-white">
+              Terms
+            </Link>
+            <Link href="/privacy" className="hover:text-white">
+              Privacy
+            </Link>
             <Link href="/register" className="hover:text-white">
               Register
             </Link>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -31,10 +31,9 @@ export default function PrivacyPage() {
           <section>
             <h2 className="text-lg font-semibold text-white mb-3">1. Who We Are</h2>
             <p>
-              InventoryAlert operates the inventory alert platform available at this domain.
-              This Privacy Policy explains what personal data we collect, how we use it, and your rights
-              regarding that data.{" "}
-              <span className="text-slate-500 italic">[Insert legal entity name and address before going live.]</span>
+              InventoryAlert is operated by Petra 413 LLC. This Privacy Policy explains what personal
+              data we collect, how we use it, and your rights regarding that data.{" "}
+              <span className="text-slate-500 italic">[Insert registered address before going live.]</span>
             </p>
           </section>
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -6,6 +6,8 @@ export const metadata: Metadata = {
 };
 
 const EFFECTIVE_DATE = "April 18, 2026";
+const CONTACT_EMAIL = process.env.LEGAL_CONTACT_EMAIL ?? "chris.cremeens@petra413.com";
+const COMPANY_ADDRESS = process.env.LEGAL_COMPANY_ADDRESS ?? "1586 Spruce Dr., Arkdale WI 54613";
 
 export default function PrivacyPage() {
   return (
@@ -31,9 +33,8 @@ export default function PrivacyPage() {
           <section>
             <h2 className="text-lg font-semibold text-white mb-3">1. Who We Are</h2>
             <p>
-              InventoryAlert is operated by Petra 413 LLC. This Privacy Policy explains what personal
-              data we collect, how we use it, and your rights regarding that data.{" "}
-              <span className="text-slate-500 italic">[Insert registered address before going live.]</span>
+              InventoryAlert is operated by Petra 413 LLC ({COMPANY_ADDRESS}). This Privacy Policy
+              explains what personal data we collect, how we use it, and your rights regarding that data.
             </p>
           </section>
 
@@ -183,8 +184,8 @@ export default function PrivacyPage() {
           <section>
             <h2 className="text-lg font-semibold text-white mb-3">11. Contact</h2>
             <p>
-              For privacy-related questions or data requests:{" "}
-              <span className="text-slate-500 italic">[Insert contact email before going live.]</span>
+              For privacy-related questions or data requests, email{" "}
+              <a href={`mailto:${CONTACT_EMAIL}`} className="text-cyan-300 hover:underline">{CONTACT_EMAIL}</a>.
             </p>
           </section>
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,207 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — InventoryAlert",
+};
+
+const EFFECTIVE_DATE = "April 18, 2026";
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-white/10">
+        <div className="mx-auto flex w-full max-w-4xl items-center justify-between px-4 py-4 sm:px-6">
+          <Link href="/" className="text-lg font-semibold tracking-tight hover:text-cyan-300 transition-colors">
+            InventoryAlert
+          </Link>
+          <div className="flex gap-3 text-sm text-slate-400">
+            <Link href="/terms" className="hover:text-white transition-colors">Terms of Service</Link>
+            <Link href="/login" className="hover:text-white transition-colors">Sign in</Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-4xl px-4 py-12 sm:px-6 sm:py-16">
+        <h1 className="text-3xl font-semibold tracking-tight text-white">Privacy Policy</h1>
+        <p className="mt-2 text-sm text-slate-400">Effective date: {EFFECTIVE_DATE}</p>
+
+        <div className="mt-10 space-y-10 text-slate-300 leading-7">
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">1. Who We Are</h2>
+            <p>
+              InventoryAlert operates the inventory alert platform available at this domain.
+              This Privacy Policy explains what personal data we collect, how we use it, and your rights
+              regarding that data.{" "}
+              <span className="text-slate-500 italic">[Insert legal entity name and address before going live.]</span>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">2. Data We Collect</h2>
+            <p>We collect the following categories of data when you use InventoryAlert:</p>
+            <ul className="mt-3 space-y-2 list-disc list-inside">
+              <li>
+                <strong className="text-white">Account data</strong> — your name (optional), email address,
+                and hashed password.
+              </li>
+              <li>
+                <strong className="text-white">Inventory data</strong> — item names, descriptions, alert
+                email addresses, low-stock thresholds, and item images you upload.
+              </li>
+              <li>
+                <strong className="text-white">Stocking requests</strong> — timestamps and status records
+                created when a QR code is scanned.
+              </li>
+              <li>
+                <strong className="text-white">Subscription data</strong> — Stripe customer ID and
+                subscription ID used to manage your billing relationship.
+              </li>
+              <li>
+                <strong className="text-white">Push notification subscriptions</strong> — browser endpoint
+                and encryption keys if you opt in to browser push notifications.
+              </li>
+              <li>
+                <strong className="text-white">Terms acceptance record</strong> — the timestamp and version
+                of the Terms of Service you accepted at registration.
+              </li>
+              <li>
+                <strong className="text-white">Password reset tokens</strong> — temporary tokens used
+                to verify password reset requests; these expire after a short window.
+              </li>
+            </ul>
+            <p className="mt-3">
+              We do <strong className="text-white">not</strong> collect payment card details. Card processing
+              is handled entirely by Stripe; we never see or store raw card numbers.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">3. How We Use Your Data</h2>
+            <ul className="mt-3 space-y-2 list-disc list-inside">
+              <li>To authenticate you and operate your account.</li>
+              <li>
+                To send low-stock alert emails to the address you configure for each inventory item.
+              </li>
+              <li>To process and manage your subscription payments via Stripe.</li>
+              <li>
+                To send transactional emails such as password resets. We do not send marketing emails
+                unless you explicitly opt in.
+              </li>
+              <li>
+                To deliver browser push notifications about new stocking requests if you have opted in.
+              </li>
+              <li>To comply with legal obligations and enforce our Terms of Service.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">4. Third-Party Data Processors</h2>
+            <p>
+              We share data with the following sub-processors, each of which operates under its own
+              privacy policy:
+            </p>
+            <ul className="mt-3 space-y-2 list-disc list-inside">
+              <li>
+                <strong className="text-white">Stripe</strong> — processes payment data for PRO
+                subscriptions. Your billing information is governed by Stripe&rsquo;s Privacy Policy.
+              </li>
+              <li>
+                <strong className="text-white">Resend</strong> — delivers transactional emails (alert
+                notifications, password resets). Email content and recipient addresses are transmitted
+                to Resend for delivery.
+              </li>
+              <li>
+                <strong className="text-white">Vercel</strong> — hosts the application and stores
+                item images you upload (via Vercel Blob). Data is stored on Vercel&rsquo;s infrastructure.
+              </li>
+            </ul>
+            <p className="mt-3">
+              We do not sell your personal data to any third party.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">5. Data Storage &amp; Retention</h2>
+            <p>
+              Your data is stored in a PostgreSQL database hosted on Vercel&rsquo;s infrastructure. Uploaded
+              item images are stored in Vercel Blob. Data is retained for as long as your account is
+              active. When you delete your account, all associated data — including inventory items,
+              stocking requests, images, and push subscriptions — is permanently and irreversibly deleted.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">6. Cookies &amp; Sessions</h2>
+            <p>
+              We use a single session cookie managed by NextAuth to keep you signed in. This is a
+              strictly necessary, HTTP-only cookie. We do not use advertising cookies, tracking pixels,
+              or third-party analytics cookies. No third-party tracking scripts are loaded on any page.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">7. QR Code Scans &amp; Public Access</h2>
+            <p>
+              Anyone who scans one of your QR labels can trigger a stocking request without creating an
+              account. The only data recorded at scan time is the item ID and the timestamp. No personal
+              data about the scanner is collected or stored.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">8. Your Rights</h2>
+            <p>
+              Depending on your jurisdiction, you may have the right to access, correct, or delete your
+              personal data, to restrict or object to processing, or to data portability. To exercise any
+              of these rights, contact us at the email below. We will respond within 30 days.
+            </p>
+            <p className="mt-3">
+              If you are in the European Economic Area, you have the right to lodge a complaint with your
+              local data protection authority.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">9. Children</h2>
+            <p>
+              InventoryAlert is not directed at children under the age of 16. We do not knowingly collect
+              personal data from anyone under 16. If you believe a minor has created an account, please
+              contact us and we will delete it promptly.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">10. Changes to This Policy</h2>
+            <p>
+              We may update this Privacy Policy from time to time. Material changes will be communicated
+              by email at least 14 days before they take effect. The effective date at the top of this
+              page reflects the most recent version.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">11. Contact</h2>
+            <p>
+              For privacy-related questions or data requests:{" "}
+              <span className="text-slate-500 italic">[Insert contact email before going live.]</span>
+            </p>
+          </section>
+
+        </div>
+      </main>
+
+      <footer className="border-t border-white/10 mt-16">
+        <div className="mx-auto flex w-full max-w-4xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-slate-400 sm:flex-row">
+          <p>InventoryAlert · Stock alerts without workflow friction.</p>
+          <div className="flex gap-4">
+            <Link href="/terms" className="hover:text-white transition-colors">Terms</Link>
+            <Link href="/privacy" className="hover:text-white transition-colors">Privacy</Link>
+            <Link href="/login" className="hover:text-white transition-colors">Sign in</Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -133,7 +133,7 @@ export default function TermsPage() {
           <section>
             <h2 className="text-lg font-semibold text-white mb-3">9. Limitation of Liability</h2>
             <p>
-              To the fullest extent permitted by law, InventoryAlert and its operators shall not be liable
+              To the fullest extent permitted by law, Petra 413 LLC and its officers shall not be liable
               for any indirect, incidental, special, or consequential damages arising from your use of the
               Service, including but not limited to:
             </p>
@@ -196,7 +196,7 @@ export default function TermsPage() {
             <h2 className="text-lg font-semibold text-white mb-3">14. Governing Law</h2>
             <p>
               These Terms are governed by and construed in accordance with applicable law. Any disputes
-              shall be resolved in the courts of the jurisdiction where InventoryAlert operates.{" "}
+              shall be resolved in the courts of the jurisdiction where Petra 413 LLC operates.{" "}
               <span className="text-slate-500 italic">[Jurisdiction to be specified before going live.]</span>
             </p>
           </section>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,227 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service — InventoryAlert",
+};
+
+const EFFECTIVE_DATE = "April 18, 2026";
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-white/10">
+        <div className="mx-auto flex w-full max-w-4xl items-center justify-between px-4 py-4 sm:px-6">
+          <Link href="/" className="text-lg font-semibold tracking-tight hover:text-cyan-300 transition-colors">
+            InventoryAlert
+          </Link>
+          <div className="flex gap-3 text-sm text-slate-400">
+            <Link href="/privacy" className="hover:text-white transition-colors">Privacy Policy</Link>
+            <Link href="/login" className="hover:text-white transition-colors">Sign in</Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-4xl px-4 py-12 sm:px-6 sm:py-16">
+        <h1 className="text-3xl font-semibold tracking-tight text-white">Terms of Service</h1>
+        <p className="mt-2 text-sm text-slate-400">Effective date: {EFFECTIVE_DATE}</p>
+
+        <div className="mt-10 space-y-10 text-slate-300 leading-7">
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">1. Service Description</h2>
+            <p>
+              InventoryAlert (&ldquo;we&rdquo;, &ldquo;our&rdquo;, &ldquo;the Service&rdquo;) provides a QR-code-based
+              inventory alert platform. Users create inventory items, generate printable QR labels, and receive
+              email notifications when a label is scanned to report low stock. The Service also maintains a
+              stocking-request queue for review and approval by the account holder.
+            </p>
+            <p className="mt-3">
+              The Service does <strong className="text-white">not</strong> physically manage, store, or purchase
+              inventory on your behalf. It is a notification and record-keeping tool only.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">2. Account &amp; Security</h2>
+            <p>
+              You must provide a valid email address and a password of at least 8 characters to create an
+              account. You are responsible for maintaining the confidentiality of your credentials and for all
+              activity that occurs under your account. You may not share your account with others or create
+              accounts on behalf of another person without their consent. Notify us immediately if you suspect
+              unauthorized use.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">3. Subscription Tiers</h2>
+            <p>The Service offers two tiers:</p>
+            <ul className="mt-3 space-y-2 list-disc list-inside">
+              <li>
+                <strong className="text-white">FREE</strong> — Up to 5 inventory items; standard QR label
+                generation; email alert delivery; access to the stocking-request dashboard.
+              </li>
+              <li>
+                <strong className="text-white">PRO</strong> — Unlimited inventory items; all FREE features;
+                custom drag-and-drop label editor with repositionable fields.
+              </li>
+            </ul>
+            <p className="mt-3">
+              Feature availability may change over time. We will give reasonable notice before removing
+              features from a tier you are currently using.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">4. Billing &amp; Auto-Renewal</h2>
+            <p>
+              PRO subscriptions are billed on a recurring monthly basis via Stripe. Your subscription
+              auto-renews at the end of each billing period unless you cancel before the renewal date.
+              Prices are displayed at checkout and on our pricing page. We reserve the right to change
+              pricing with at least 30 days&rsquo; notice to your registered email address.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">5. Cancellation &amp; Refunds</h2>
+            <p>
+              You may cancel your PRO subscription at any time via the billing portal in your account
+              settings. Upon cancellation, your subscription remains active until the end of the current
+              paid billing period; you will not be charged again after that. We do not issue prorated
+              refunds for unused time in a billing period. If you believe a charge was made in error,
+              contact us within 30 days of the charge.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">6. Acceptable Use</h2>
+            <p>You agree not to use the Service to:</p>
+            <ul className="mt-3 space-y-2 list-disc list-inside">
+              <li>Generate, distribute, or use QR codes for spam, phishing, fraud, or deceptive purposes.</li>
+              <li>Circumvent access controls of any system or third-party service.</li>
+              <li>Scrape, crawl, or programmatically extract data from the Service beyond normal API use.</li>
+              <li>Upload content that infringes intellectual property rights or contains malware.</li>
+              <li>Transmit unsolicited bulk email using alert email addresses obtained through the Service.</li>
+              <li>Violate any applicable law or regulation.</li>
+            </ul>
+            <p className="mt-3">
+              We reserve the right to suspend or terminate accounts that violate this policy.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">7. Email Alerts Sent on Your Behalf</h2>
+            <p>
+              When a QR code is scanned, the Service sends an alert email to the address you configured for
+              that item. These emails are sent from InventoryAlert&rsquo;s sending infrastructure (powered by
+              Resend). You are responsible for ensuring that the configured alert email address is correct and
+              that you have consent to send alerts there. We are not liable if an alert email fails to
+              deliver due to recipient-side filtering, Resend infrastructure issues, or incorrect
+              configuration.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">8. No Uptime Guarantee</h2>
+            <p>
+              The Service is provided &ldquo;as is&rdquo; without any warranty of availability or uptime. We make
+              commercially reasonable efforts to maintain service availability but do not guarantee
+              uninterrupted access. Scheduled or emergency maintenance may occur without advance notice.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">9. Limitation of Liability</h2>
+            <p>
+              To the fullest extent permitted by law, InventoryAlert and its operators shall not be liable
+              for any indirect, incidental, special, or consequential damages arising from your use of the
+              Service, including but not limited to:
+            </p>
+            <ul className="mt-3 space-y-2 list-disc list-inside">
+              <li>Losses caused by a missed, delayed, or undelivered alert email.</li>
+              <li>Stock-out events, lost sales, or operational disruptions attributable to the Service.</li>
+              <li>Data loss resulting from account deletion or service interruption.</li>
+            </ul>
+            <p className="mt-3">
+              Our total cumulative liability to you for any claim arising out of these Terms shall not exceed
+              the fees you paid to us in the three months preceding the claim.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">10. Third-Party Services</h2>
+            <p>
+              The Service relies on the following third parties whose own terms and policies apply to their
+              respective services:
+            </p>
+            <ul className="mt-3 space-y-2 list-disc list-inside">
+              <li><strong className="text-white">Stripe</strong> — payment processing and subscription management.</li>
+              <li><strong className="text-white">Resend</strong> — transactional email delivery.</li>
+              <li><strong className="text-white">Vercel</strong> — hosting and file (image) storage.</li>
+            </ul>
+            <p className="mt-3">
+              We are not responsible for the availability or conduct of these third-party services.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">11. Data on Account Deletion</h2>
+            <p>
+              When you delete your account, all associated data is permanently removed, including inventory
+              items, QR codes, stocking requests, uploaded images, and push notification subscriptions.
+              This action is irreversible. Export any data you need before deleting your account.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">12. Termination by Us</h2>
+            <p>
+              We may suspend or terminate your account at our discretion if we believe you have violated
+              these Terms, engaged in fraudulent activity, or posed a risk to other users or to the Service.
+              Where reasonably practicable, we will notify you before termination and give you an opportunity
+              to respond. Upon termination, your right to use the Service ceases immediately.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">13. Changes to These Terms</h2>
+            <p>
+              We may update these Terms from time to time. We will notify you of material changes by email
+              at least 14 days before they take effect. Continued use of the Service after the effective
+              date constitutes acceptance of the revised Terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">14. Governing Law</h2>
+            <p>
+              These Terms are governed by and construed in accordance with applicable law. Any disputes
+              shall be resolved in the courts of the jurisdiction where InventoryAlert operates.{" "}
+              <span className="text-slate-500 italic">[Jurisdiction to be specified before going live.]</span>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-white mb-3">15. Contact</h2>
+            <p>
+              Questions about these Terms?{" "}
+              <span className="text-slate-500 italic">[Insert contact email before going live.]</span>
+            </p>
+          </section>
+
+        </div>
+      </main>
+
+      <footer className="border-t border-white/10 mt-16">
+        <div className="mx-auto flex w-full max-w-4xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-slate-400 sm:flex-row">
+          <p>InventoryAlert · Stock alerts without workflow friction.</p>
+          <div className="flex gap-4">
+            <Link href="/terms" className="hover:text-white transition-colors">Terms</Link>
+            <Link href="/privacy" className="hover:text-white transition-colors">Privacy</Link>
+            <Link href="/login" className="hover:text-white transition-colors">Sign in</Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -6,6 +6,8 @@ export const metadata: Metadata = {
 };
 
 const EFFECTIVE_DATE = "April 18, 2026";
+const CONTACT_EMAIL = process.env.LEGAL_CONTACT_EMAIL ?? "chris.cremeens@petra413.com";
+const COMPANY_ADDRESS = process.env.LEGAL_COMPANY_ADDRESS ?? "1586 Spruce Dr., Arkdale WI 54613";
 
 export default function TermsPage() {
   return (
@@ -196,16 +198,16 @@ export default function TermsPage() {
             <h2 className="text-lg font-semibold text-white mb-3">14. Governing Law</h2>
             <p>
               These Terms are governed by and construed in accordance with applicable law. Any disputes
-              shall be resolved in the courts of the jurisdiction where Petra 413 LLC operates.{" "}
-              <span className="text-slate-500 italic">[Jurisdiction to be specified before going live.]</span>
+              shall be resolved in the courts of the State of Wisconsin, USA.
             </p>
           </section>
 
           <section>
             <h2 className="text-lg font-semibold text-white mb-3">15. Contact</h2>
             <p>
-              Questions about these Terms?{" "}
-              <span className="text-slate-500 italic">[Insert contact email before going live.]</span>
+              Questions about these Terms? Email us at{" "}
+              <a href={`mailto:${CONTACT_EMAIL}`} className="text-cyan-300 hover:underline">{CONTACT_EMAIL}</a>.
+              Petra 413 LLC · {COMPANY_ADDRESS}
             </p>
           </section>
 

--- a/prisma/migrations/20260418210000_add_terms_accepted/migration.sql
+++ b/prisma/migrations/20260418210000_add_terms_accepted/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "termsAcceptedAt" TIMESTAMP(3),
+ADD COLUMN "termsVersion" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,8 @@ model User {
   stripeCurrentPeriodEnd DateTime?
   passwordResetToken     String?
   passwordResetExpiry    DateTime?
+  termsAcceptedAt        DateTime?
+  termsVersion           String?
   createdAt              DateTime        @default(now())
   updatedAt              DateTime        @updatedAt
 


### PR DESCRIPTION
- Create app/terms/page.tsx with InventoryAlert-specific ToS covering service
  description, subscription tiers, billing, cancellation, acceptable use,
  email alert liability, third-party services, and governing law
- Create app/privacy/page.tsx covering data collected, processors (Stripe/Resend/Vercel),
  retention, session cookies, QR scan anonymity, and user rights (GDPR/CCPA)
- Add mandatory T&C checkbox to registration form; submit disabled until accepted
- Validate termsAccepted: true in register API (Zod literal) and store
  termsAcceptedAt + termsVersion on the User record
- Add consent_collection + custom_text to Stripe checkout session for PRO upgrades
- Add Terms and Privacy links to public landing page footer
- Add termsAcceptedAt / termsVersion fields to User model + migration

https://claude.ai/code/session_014CxAE15cia41M9krFRRAK2