### PR TITLE
Add Terms of Service, Privacy Policy, and T&C acknowledgment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ STRIPE_PRODUCT_PRO="prod_..."
 BLOB_READ_WRITE_TOKEN="vercel_blob_..."
 
 # Legal / compliance (used in Terms of Service and Privacy Policy pages)
-LEGAL_CONTACT_EMAIL="chris.cremeens@petra413.com"
+LEGAL_CONTACT_EMAIL="help@petra413.com"
 LEGAL_COMPANY_ADDRESS="1586 Spruce Dr., Arkdale WI 54613"
 
 # Web Push (VAPID) — required for phone push notifications

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
 };
 
 const EFFECTIVE_DATE = "April 18, 2026";
-const CONTACT_EMAIL = process.env.LEGAL_CONTACT_EMAIL ?? "chris.cremeens@petra413.com";
+const CONTACT_EMAIL = process.env.LEGAL_CONTACT_EMAIL ?? "help@petra413.com";
 const COMPANY_ADDRESS = process.env.LEGAL_COMPANY_ADDRESS ?? "1586 Spruce Dr., Arkdale WI 54613";
 
 export default function PrivacyPage() {

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
 };
 
 const EFFECTIVE_DATE = "April 18, 2026";
-const CONTACT_EMAIL = process.env.LEGAL_CONTACT_EMAIL ?? "chris.cremeens@petra413.com";
+const CONTACT_EMAIL = process.env.LEGAL_CONTACT_EMAIL ?? "help@petra413.com";
 const COMPANY_ADDRESS = process.env.LEGAL_COMPANY_ADDRESS ?? "1586 Spruce Dr., Arkdale WI 54613";
 
 export default function TermsPage() {


### PR DESCRIPTION
## Summary

- Add `/terms` and `/privacy` pages with InventoryAlert-specific content (operated by Petra 413 LLC, Wisconsin jurisdiction, `help@petra413.com` contact)
- Add mandatory T&C checkbox to registration form — submit is disabled until accepted; `termsAcceptedAt` and `termsVersion` stored on the User record
- Validate `termsAccepted: true` in the register API via Zod, rejecting requests that skip the checkbox
- Add T&C consent display to Stripe checkout session for PRO upgrades
- Add Terms and Privacy links to the public landing page footer
- Add `termsAcceptedAt` / `termsVersion` fields to Prisma User model with migration
- Contact email and company address are env-var-driven (`LEGAL_CONTACT_EMAIL`, `LEGAL_COMPANY_ADDRESS`) with current values as fallbacks

## Test plan

- [ ] Navigate to `/terms` and `/privacy` — confirm pages render with correct entity name, address, email, and Wisconsin jurisdiction
- [ ] Go to `/register` — confirm T&C checkbox is present and submit button is disabled until checked
- [ ] Register a new account with checkbox checked — confirm redirect to `/login?registered=1`
- [ ] Check DB: `termsAcceptedAt` and `termsVersion` are set on the new user row
- [ ] POST `/api/auth/register` without `termsAccepted: true` — confirm 400 response
- [ ] Initiate PRO upgrade — confirm Stripe checkout shows T&C acceptance field linking to `/terms`
- [ ] Confirm Terms and Privacy links appear in landing page footer

https://claude.ai/code/session_014CxAE15cia41M9krFRRAK2