### PR TITLE
Add Pro contacts and multi-recipient alerts

### DIFF
--- a/app/(dashboard)/contacts/ContactsClient.tsx
+++ b/app/(dashboard)/contacts/ContactsClient.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type Contact = {
+  id: string;
+  name: string;
+  email: string;
+  cellPhone: string | null;
+  emailEnabled: boolean;
+  smsOptIn: boolean;
+  assignedItemCount: number;
+};
+
+const emptyForm = {
+  name: "",
+  email: "",
+  cellPhone: "",
+  emailEnabled: true,
+  smsOptIn: false,
+};
+
+export default function ContactsClient({ initialContacts }: { initialContacts: Contact[] }) {
+  const router = useRouter();
+  const [contacts, setContacts] = useState(initialContacts);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState(emptyForm);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  function resetForm() {
+    setEditingId(null);
+    setForm(emptyForm);
+  }
+
+  function startEditing(contact: Contact) {
+    setEditingId(contact.id);
+    setForm({
+      name: contact.name,
+      email: contact.email,
+      cellPhone: contact.cellPhone ?? "",
+      emailEnabled: contact.emailEnabled,
+      smsOptIn: contact.smsOptIn,
+    });
+    setError("");
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    const payload = {
+      name: form.name,
+      email: form.email,
+      cellPhone: form.cellPhone || undefined,
+      emailEnabled: form.emailEnabled,
+      smsOptIn: form.smsOptIn,
+    };
+
+    try {
+      const res = await fetch(
+        editingId ? `/api/contacts/${editingId}` : "/api/contacts",
+        {
+          method: editingId ? "PATCH" : "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }
+      );
+      const data = await res.json();
+      setLoading(false);
+
+      if (!res.ok) {
+        setError(data.error || "Something went wrong.");
+        return;
+      }
+
+      if (editingId) {
+        setContacts((prev) =>
+          prev.map((contact) =>
+            contact.id === editingId
+              ? { ...contact, ...data }
+              : contact
+          )
+        );
+      } else {
+        setContacts((prev) => [{ ...data, assignedItemCount: 0 }, ...prev]);
+      }
+
+      resetForm();
+      router.refresh();
+    } catch {
+      setLoading(false);
+      setError("An unexpected error occurred. Please try again.");
+    }
+  }
+
+  async function handleDelete(contact: Contact) {
+    if (!confirm(`Delete "${contact.name}"?`)) return;
+
+    setError("");
+    setDeletingId(contact.id);
+
+    try {
+      const res = await fetch(`/api/contacts/${contact.id}`, { method: "DELETE" });
+      const data = await res.json();
+      setDeletingId(null);
+
+      if (!res.ok) {
+        setError(data.error || "Could not delete contact.");
+        return;
+      }
+
+      setContacts((prev) => prev.filter((current) => current.id !== contact.id));
+      if (editingId === contact.id) resetForm();
+      router.refresh();
+    } catch {
+      setDeletingId(null);
+      setError("An unexpected error occurred. Please try again.");
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="bg-surface-container-lowest rounded-xl shadow-sm p-4 sm:p-6 space-y-4">
+        <div>
+          <h2 className="font-semibold text-on-surface font-headline">
+            {editingId ? "Edit Contact" : "New Contact"}
+          </h2>
+          <p className="text-sm text-on-surface-variant mt-1">
+            Contacts can be reused across items. Email muting is managed here.
+          </p>
+        </div>
+
+        {error && (
+          <div className="bg-error-container border border-error/20 text-on-error-container text-sm rounded-lg px-4 py-3">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium text-on-surface-variant mb-1">
+              Name
+            </label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+              required
+              maxLength={100}
+              className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-on-surface-variant mb-1">
+              Email
+            </label>
+            <input
+              type="email"
+              value={form.email}
+              onChange={(e) => setForm((prev) => ({ ...prev, email: e.target.value }))}
+              required
+              className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-on-surface-variant mb-1">
+              Cell phone
+            </label>
+            <input
+              type="tel"
+              value={form.cellPhone}
+              onChange={(e) => setForm((prev) => ({ ...prev, cellPhone: e.target.value }))}
+              maxLength={30}
+              placeholder="Optional"
+              className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
+            />
+          </div>
+
+          <div className="space-y-3 rounded-xl border border-outline-variant bg-surface-container-low p-4">
+            <label className="flex items-center justify-between gap-3">
+              <span>
+                <span className="block text-sm font-medium text-on-surface">Email alerts</span>
+                <span className="block text-xs text-on-surface-variant">
+                  Allow this contact to receive alert emails.
+                </span>
+              </span>
+              <input
+                type="checkbox"
+                checked={form.emailEnabled}
+                onChange={(e) => setForm((prev) => ({ ...prev, emailEnabled: e.target.checked }))}
+                className="h-4 w-4 accent-primary"
+              />
+            </label>
+
+            <label className="flex items-center justify-between gap-3">
+              <span>
+                <span className="block text-sm font-medium text-on-surface">SMS opt-in</span>
+                <span className="block text-xs text-on-surface-variant">
+                  Stored for future SMS support. No texts are sent yet.
+                </span>
+              </span>
+              <input
+                type="checkbox"
+                checked={form.smsOptIn}
+                onChange={(e) => setForm((prev) => ({ ...prev, smsOptIn: e.target.checked }))}
+                className="h-4 w-4 accent-primary"
+              />
+            </label>
+          </div>
+
+          <div className="md:col-span-2 flex flex-col-reverse gap-3 pt-2 sm:flex-row">
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full sm:w-auto bg-primary text-on-primary rounded-full px-5 py-2 text-sm font-medium hover:bg-primary-container disabled:opacity-50 transition-colors"
+            >
+              {loading ? (editingId ? "Saving..." : "Creating...") : editingId ? "Save contact" : "Create contact"}
+            </button>
+            {editingId && (
+              <button
+                type="button"
+                onClick={resetForm}
+                className="w-full sm:w-auto border border-outline text-on-surface rounded-full px-5 py-2 text-sm hover:bg-surface-container-low transition-colors"
+              >
+                Cancel edit
+              </button>
+            )}
+          </div>
+        </form>
+      </section>
+
+      <section className="bg-surface-container-lowest rounded-xl shadow-sm overflow-hidden">
+        {contacts.length === 0 ? (
+          <div className="px-5 py-12 text-center text-on-surface-variant text-sm">
+            No contacts yet. Create one above to reuse it across inventory items.
+          </div>
+        ) : (
+          <ul className="divide-y divide-outline-variant">
+            {contacts.map((contact) => (
+              <li key={contact.id} className="p-4 sm:p-5">
+                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="font-semibold text-on-surface">{contact.name}</h3>
+                      {!contact.emailEnabled && (
+                        <span className="inline-flex items-center rounded-full bg-surface-container-high px-2 py-0.5 text-[10px] font-medium text-on-surface-variant">
+                          Email muted
+                        </span>
+                      )}
+                      {contact.smsOptIn && (
+                        <span className="inline-flex items-center rounded-full bg-secondary-container/40 px-2 py-0.5 text-[10px] font-medium text-on-secondary-container">
+                          SMS opt-in
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-on-surface-variant break-all">{contact.email}</p>
+                    <p className="text-xs text-on-surface-variant">
+                      Cell phone: {contact.cellPhone || "-"}
+                    </p>
+                    <p className="text-xs text-on-surface-variant">
+                      Assigned to {contact.assignedItemCount} item{contact.assignedItemCount === 1 ? "" : "s"}
+                    </p>
+                  </div>
+
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <button
+                      type="button"
+                      onClick={() => startEditing(contact)}
+                      className="border border-outline text-on-surface rounded-full px-4 py-2 text-sm hover:bg-surface-container-low transition-colors"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(contact)}
+                      disabled={deletingId === contact.id}
+                      className="border border-error/30 text-error rounded-full px-4 py-2 text-sm hover:bg-error-container disabled:opacity-50 transition-colors"
+                    >
+                      {deletingId === contact.id ? "Deleting..." : "Delete"}
+                    </button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/(dashboard)/contacts/page.tsx
+++ b/app/(dashboard)/contacts/page.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import ContactsClient from "./ContactsClient";
+
+export default async function ContactsPage() {
+  const session = await auth();
+  if (!session) return null;
+
+  if (session.user.tier !== "PRO") {
+    return (
+      <div className="max-w-2xl space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-on-surface font-headline">Contacts</h1>
+          <p className="text-sm text-on-surface-variant mt-1">
+            Reusable alert contacts are available on the Pro plan.
+          </p>
+        </div>
+
+        <div className="bg-surface-container-lowest rounded-xl shadow-sm p-6 space-y-4">
+          <p className="text-on-surface font-medium">
+            Upgrade to Pro to manage shared alert recipients.
+          </p>
+          <p className="text-sm text-on-surface-variant">
+            Pro contacts let you reuse recipients across items, mute email delivery per contact,
+            and store cell phone numbers for future SMS support.
+          </p>
+          <Link
+            href="/settings"
+            className="inline-flex items-center rounded-full bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary-container transition-colors"
+          >
+            Upgrade in Settings
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const contacts = await prisma.alertContact.findMany({
+    where: { userId: session.user.id },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      cellPhone: true,
+      emailEnabled: true,
+      smsOptIn: true,
+      createdAt: true,
+      updatedAt: true,
+      _count: {
+        select: {
+          itemRecipients: true,
+        },
+      },
+    },
+    orderBy: [{ name: "asc" }, { email: "asc" }],
+  });
+
+  return (
+    <div className="max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-on-surface font-headline">Contacts</h1>
+        <p className="text-sm text-on-surface-variant mt-1">
+          Manage shared notification recipients for your Pro inventory alerts.
+        </p>
+      </div>
+
+      <ContactsClient
+        initialContacts={contacts.map((contact) => ({
+          id: contact.id,
+          name: contact.name,
+          email: contact.email,
+          cellPhone: contact.cellPhone,
+          emailEnabled: contact.emailEnabled,
+          smsOptIn: contact.smsOptIn,
+          assignedItemCount: contact._count.itemRecipients,
+        }))}
+      />
+    </div>
+  );
+}

--- a/app/(dashboard)/items/[itemId]/page.tsx
+++ b/app/(dashboard)/items/[itemId]/page.tsx
@@ -30,12 +30,52 @@ export default async function EditItemPage({
   if (!session) return null;
 
   const { itemId } = await params;
-  const item = await prisma.inventoryItem.findUnique({ where: { id: itemId } });
+  const [item, contacts] = await Promise.all([
+    prisma.inventoryItem.findUnique({
+      where: { id: itemId },
+      include: {
+        alertRecipients: {
+          orderBy: { position: "asc" },
+          select: {
+            id: true,
+            kind: true,
+            contactId: true,
+            inlineEmail: true,
+            contact: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                cellPhone: true,
+                emailEnabled: true,
+                smsOptIn: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+    prisma.alertContact.findMany({
+      where: { userId: session.user.id },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        cellPhone: true,
+        emailEnabled: true,
+        smsOptIn: true,
+      },
+      orderBy: [{ name: "asc" }, { email: "asc" }],
+    }),
+  ]);
 
   if (!item || item.userId !== session.user.id) notFound();
 
   const canCustomizeLabels = TIER_LIMITS[session.user.tier].customLabels;
   const savedLayout = parseLabelLayout(item.labelLayout);
+  const hasLockedProRecipients =
+    session.user.tier !== "PRO" &&
+    (item.alertRecipients.length !== 1 || item.alertRecipients[0]?.kind !== "INLINE_EMAIL");
 
   return (
     <div className="max-w-lg">
@@ -51,7 +91,38 @@ export default async function EditItemPage({
         canCustomizeLabels={canCustomizeLabels}
       />
 
-      <ItemForm item={item} mode="edit" currentTier={session.user.tier} />
+      <ItemForm
+        item={{
+          id: item.id,
+          name: item.name,
+          description: item.description,
+          alertEmail: item.alertEmail,
+          imageUrl: item.imageUrl,
+          lowStockThreshold: item.lowStockThreshold,
+          alertEmailEnabled: item.alertEmailEnabled,
+          scanCooldownMinutes: item.scanCooldownMinutes,
+          scanAcknowledgement: item.scanAcknowledgement,
+          alertRecipients: item.alertRecipients.map((recipient) => {
+            if (recipient.kind === "CONTACT" && recipient.contactId) {
+              return {
+                clientId: recipient.id,
+                kind: "CONTACT" as const,
+                contactId: recipient.contactId,
+              };
+            }
+
+            return {
+              clientId: recipient.id,
+              kind: "INLINE_EMAIL" as const,
+              email: recipient.inlineEmail ?? "",
+            };
+          }),
+        }}
+        mode="edit"
+        currentTier={session.user.tier}
+        contacts={contacts}
+        hasLockedProRecipients={hasLockedProRecipients}
+      />
     </div>
   );
 }

--- a/app/(dashboard)/items/new/page.tsx
+++ b/app/(dashboard)/items/new/page.tsx
@@ -8,9 +8,25 @@ export default async function NewItemPage() {
   const session = await auth();
   if (!session) return null;
 
-  const count = await prisma.inventoryItem.count({
-    where: { userId: session.user.id },
-  });
+  const [count, contacts] = await Promise.all([
+    prisma.inventoryItem.count({
+      where: { userId: session.user.id },
+    }),
+    session.user.tier === "PRO"
+      ? prisma.alertContact.findMany({
+          where: { userId: session.user.id },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            cellPhone: true,
+            emailEnabled: true,
+            smsOptIn: true,
+          },
+          orderBy: [{ name: "asc" }, { email: "asc" }],
+        })
+      : Promise.resolve([]),
+  ]);
 
   const allowed = canCreateItem(session.user.tier, count);
 
@@ -39,7 +55,11 @@ export default async function NewItemPage() {
   return (
     <div className="max-w-lg">
       <h1 className="text-2xl font-bold text-on-surface font-headline mb-6">New Item</h1>
-      <ItemForm mode="create" currentTier={session.user.tier} />
+      <ItemForm
+        mode="create"
+        currentTier={session.user.tier}
+        contacts={contacts}
+      />
     </div>
   );
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -20,12 +20,12 @@ export default async function DashboardLayout({
       <div className="flex flex-col min-h-screen bg-background">
         <MobileHeader />
         <div className="flex flex-1">
-          <Sidebar />
+          <Sidebar currentTier={session.user.tier} />
           <main className="flex-1 overflow-auto pb-[calc(5rem+env(safe-area-inset-bottom))] md:pb-0">
             <div className="p-4 md:p-8">{children}</div>
           </main>
         </div>
-        <BottomNav />
+        <BottomNav currentTier={session.user.tier} />
         <InstallBanner />
         <Link
           href="/items/new"

--- a/app/api/contacts/[contactId]/route.ts
+++ b/app/api/contacts/[contactId]/route.ts
@@ -1,0 +1,205 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import {
+  getEffectiveRecipientEmails,
+  isProTier,
+  normalizeContactInput,
+  refreshItemAlertEmailMirrors,
+} from "@/lib/alert-recipients";
+import { updateAlertContactSchema } from "@/lib/validations/contact";
+
+type Params = { params: Promise<{ contactId: string }> };
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+  try {
+    const session = await auth();
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    if (!isProTier(session.user.tier)) {
+      return NextResponse.json(
+        { error: "Contacts are a Pro feature.", code: "PRO_FEATURE_REQUIRED" },
+        { status: 403 }
+      );
+    }
+
+    const { contactId } = await params;
+    const existing = await prisma.alertContact.findUnique({
+      where: { id: contactId },
+      select: {
+        id: true,
+        userId: true,
+        itemRecipients: {
+          select: {
+            itemId: true,
+          },
+        },
+      },
+    });
+
+    if (!existing || existing.userId !== session.user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const body = await req.json();
+    const parsed = updateAlertContactSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const normalized = normalizeContactInput({
+      name: parsed.data.name ?? "",
+      email: parsed.data.email ?? "",
+      cellPhone: parsed.data.cellPhone,
+      emailEnabled: parsed.data.emailEnabled,
+      smsOptIn: parsed.data.smsOptIn,
+    });
+
+    const data = {
+      ...(parsed.data.name !== undefined && { name: normalized.name }),
+      ...(parsed.data.email !== undefined && {
+        email: normalized.email,
+        emailNormalized: normalized.emailNormalized,
+      }),
+      ...(parsed.data.cellPhone !== undefined && { cellPhone: normalized.cellPhone }),
+      ...(parsed.data.emailEnabled !== undefined && { emailEnabled: normalized.emailEnabled }),
+      ...(parsed.data.smsOptIn !== undefined && { smsOptIn: normalized.smsOptIn }),
+    };
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const contact = await tx.alertContact.update({
+        where: { id: contactId },
+        data,
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          cellPhone: true,
+          emailEnabled: true,
+          smsOptIn: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+
+      await refreshItemAlertEmailMirrors(
+        tx,
+        existing.itemRecipients.map((recipient) => recipient.itemId)
+      );
+
+      return contact;
+    });
+
+    return NextResponse.json(updated);
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return NextResponse.json(
+        { error: "A contact with this email already exists." },
+        { status: 409 }
+      );
+    }
+
+    console.error("[PATCH /api/contacts/[contactId]]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(_req: NextRequest, { params }: Params) {
+  try {
+    const session = await auth();
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    if (!isProTier(session.user.tier)) {
+      return NextResponse.json(
+        { error: "Contacts are a Pro feature.", code: "PRO_FEATURE_REQUIRED" },
+        { status: 403 }
+      );
+    }
+
+    const { contactId } = await params;
+    const existing = await prisma.alertContact.findUnique({
+      where: { id: contactId },
+      select: {
+        id: true,
+        userId: true,
+        itemRecipients: {
+          select: {
+            itemId: true,
+          },
+        },
+      },
+    });
+
+    if (!existing || existing.userId !== session.user.id) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const impactedItemIds = existing.itemRecipients.map((recipient) => recipient.itemId);
+    const impactedItems = impactedItemIds.length
+      ? await prisma.inventoryItem.findMany({
+          where: {
+            id: { in: impactedItemIds },
+            alertEmailEnabled: true,
+          },
+          select: {
+            id: true,
+            name: true,
+            alertRecipients: {
+              orderBy: { position: "asc" },
+              select: {
+                kind: true,
+                contactId: true,
+                inlineEmail: true,
+                contact: {
+                  select: {
+                    id: true,
+                    email: true,
+                    emailEnabled: true,
+                  },
+                },
+              },
+            },
+          },
+        })
+      : [];
+
+    const blockingItems = impactedItems.filter((item) => {
+      const remainingRecipients = item.alertRecipients.filter(
+        (recipient) => recipient.contact?.id !== contactId
+      );
+      return getEffectiveRecipientEmails(remainingRecipients).length === 0;
+    });
+
+    if (blockingItems.length > 0) {
+      return NextResponse.json(
+        {
+          error:
+            blockingItems.length === 1
+              ? `Cannot delete this contact because "${blockingItems[0].name}" would have no remaining recipients.`
+              : `Cannot delete this contact because ${blockingItems.length} items would have no remaining recipients.`,
+        },
+        { status: 400 }
+      );
+    }
+
+    await prisma.$transaction(async (tx) => {
+      await tx.alertContact.delete({
+        where: { id: contactId },
+      });
+
+      await refreshItemAlertEmailMirrors(tx, impactedItemIds);
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[DELETE /api/contacts/[contactId]]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/contacts/route.ts
+++ b/app/api/contacts/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { normalizeContactInput, RecipientConfigError, isProTier } from "@/lib/alert-recipients";
+import { alertContactSchema } from "@/lib/validations/contact";
+
+export async function GET() {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (!isProTier(session.user.tier)) {
+    return NextResponse.json(
+      { error: "Contacts are a Pro feature.", code: "PRO_FEATURE_REQUIRED" },
+      { status: 403 }
+    );
+  }
+
+  const contacts = await prisma.alertContact.findMany({
+    where: { userId: session.user.id },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      cellPhone: true,
+      emailEnabled: true,
+      smsOptIn: true,
+      createdAt: true,
+      updatedAt: true,
+      _count: { select: { itemRecipients: true } },
+    },
+    orderBy: [{ name: "asc" }, { email: "asc" }],
+  });
+
+  return NextResponse.json(
+    contacts.map(({ _count, ...contact }) => ({
+      ...contact,
+      assignedItemCount: _count.itemRecipients,
+    }))
+  );
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    if (!isProTier(session.user.tier)) {
+      return NextResponse.json(
+        { error: "Contacts are a Pro feature.", code: "PRO_FEATURE_REQUIRED" },
+        { status: 403 }
+      );
+    }
+
+    const body = await req.json();
+    const parsed = alertContactSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    const created = await prisma.alertContact.create({
+      data: {
+        userId: session.user.id,
+        ...normalizeContactInput(parsed.data),
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        cellPhone: true,
+        emailEnabled: true,
+        smsOptIn: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return NextResponse.json(created, { status: 201 });
+  } catch (err) {
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === "P2002"
+    ) {
+      return NextResponse.json(
+        { error: "A contact with this email already exists." },
+        { status: 409 }
+      );
+    }
+
+    if (err instanceof RecipientConfigError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+
+    console.error("[POST /api/contacts]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/items/[itemId]/route.ts
+++ b/app/api/items/[itemId]/route.ts
@@ -4,11 +4,40 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { updateItemSchema } from "@/lib/validations/item";
+import {
+  RecipientConfigError,
+  refreshItemAlertEmailMirrors,
+  resolveRecipientWritePayload,
+} from "@/lib/alert-recipients";
 
 type Params = { params: Promise<{ itemId: string }> };
 
 async function getOwnedItem(itemId: string, userId: string) {
-  const item = await prisma.inventoryItem.findUnique({ where: { id: itemId } });
+  const item = await prisma.inventoryItem.findUnique({
+    where: { id: itemId },
+    include: {
+      alertRecipients: {
+        orderBy: { position: "asc" },
+        select: {
+          id: true,
+          kind: true,
+          contactId: true,
+          inlineEmail: true,
+          position: true,
+          contact: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              cellPhone: true,
+              emailEnabled: true,
+              smsOptIn: true,
+            },
+          },
+        },
+      },
+    },
+  });
   if (!item || item.userId !== userId) return null;
   return item;
 }
@@ -25,57 +54,130 @@ export async function GET(_req: NextRequest, { params }: Params) {
 }
 
 export async function PATCH(req: NextRequest, { params }: Params) {
-  const session = await auth();
-  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    const session = await auth();
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { itemId } = await params;
-  const existing = await getOwnedItem(itemId, session.user.id);
-  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const { itemId } = await params;
+    const existing = await getOwnedItem(itemId, session.user.id);
+    if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  const body = await req.json();
-  const parsed = updateItemSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.issues[0].message },
-      { status: 400 }
-    );
-  }
-
-  const { labelLayout, ...rest } = parsed.data;
-  const scanAcknowledgement = rest.scanAcknowledgement?.trim();
-
-  if (session.user.tier !== "PRO") {
-    const hasCustomCooldown =
-      rest.scanCooldownMinutes !== undefined && rest.scanCooldownMinutes !== 60;
-    const hasCustomAcknowledgement = !!scanAcknowledgement;
-
-    if (hasCustomCooldown || hasCustomAcknowledgement) {
+    const body = await req.json();
+    const parsed = updateItemSchema.safeParse(body);
+    if (!parsed.success) {
       return NextResponse.json(
-        {
-          error: "Custom scan timeout and acknowledgement are Pro features.",
-          code: "PRO_FEATURE_REQUIRED",
-        },
-        { status: 403 }
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
       );
     }
+
+    const { labelLayout, alertRecipients, alertEmail, ...rest } = parsed.data;
+    const scanAcknowledgement = rest.scanAcknowledgement?.trim();
+
+    if (session.user.tier !== "PRO") {
+      const hasCustomCooldown =
+        rest.scanCooldownMinutes !== undefined && rest.scanCooldownMinutes !== 60;
+      const hasCustomAcknowledgement = !!scanAcknowledgement;
+
+      if (hasCustomCooldown || hasCustomAcknowledgement) {
+        return NextResponse.json(
+          {
+            error: "Custom scan timeout and acknowledgement are Pro features.",
+            code: "PRO_FEATURE_REQUIRED",
+          },
+          { status: 403 }
+        );
+      }
+    }
+
+    const hasComplexProRecipients =
+      existing.alertRecipients.length !== 1 ||
+      existing.alertRecipients[0]?.kind !== "INLINE_EMAIL";
+    const shouldReplaceRecipients =
+      alertRecipients !== undefined ||
+      (alertEmail !== undefined && (!hasComplexProRecipients || session.user.tier === "PRO")) ||
+      (session.user.tier !== "PRO" && !hasComplexProRecipients);
+
+    if (session.user.tier !== "PRO" && hasComplexProRecipients) {
+      if (alertRecipients !== undefined || alertEmail !== undefined) {
+        return NextResponse.json(
+          {
+            error: "Multi-recipient alerts are a Pro feature. Upgrade to edit this item's recipients.",
+            code: "PRO_FEATURE_REQUIRED",
+          },
+          { status: 403 }
+        );
+      }
+    }
+
+    const updated = await prisma.$transaction(async (tx) => {
+      let primaryAlertEmail = existing.alertEmail;
+
+      if (shouldReplaceRecipients) {
+        const resolvedRecipients = await resolveRecipientWritePayload({
+          tx,
+          userId: session.user.id,
+          tier: session.user.tier,
+          alertEmail,
+          alertRecipients,
+          fallbackAlertEmail: existing.alertEmail,
+        });
+
+        const nextAlertsEnabled = rest.alertEmailEnabled ?? existing.alertEmailEnabled;
+        if (nextAlertsEnabled && resolvedRecipients.effectiveRecipientCount === 0) {
+          throw new RecipientConfigError(
+            "At least one email-enabled recipient is required while alerts are enabled."
+          );
+        }
+
+        primaryAlertEmail = resolvedRecipients.primaryAlertEmail;
+
+        await tx.inventoryItemRecipient.deleteMany({
+          where: { itemId },
+        });
+
+        await tx.inventoryItemRecipient.createMany({
+          data: resolvedRecipients.recipients.map((recipient) => ({
+            ...recipient,
+            itemId,
+          })),
+        });
+      }
+
+      const updatedItem = await tx.inventoryItem.update({
+        where: { id: itemId },
+        data: {
+          ...rest,
+          ...(shouldReplaceRecipients && { alertEmail: primaryAlertEmail }),
+          imageUrl: rest.imageUrl !== undefined ? rest.imageUrl || null : undefined,
+          ...(rest.scanAcknowledgement !== undefined && {
+            scanAcknowledgement: scanAcknowledgement || null,
+          }),
+          ...(labelLayout !== undefined && {
+            labelLayout: labelLayout === null ? Prisma.JsonNull : labelLayout,
+          }),
+        },
+      });
+
+      if (!shouldReplaceRecipients && rest.alertEmailEnabled !== undefined) {
+        await refreshItemAlertEmailMirrors(tx, [itemId]);
+      }
+
+      return updatedItem;
+    });
+
+    return NextResponse.json(updated);
+  } catch (err) {
+    if (err instanceof RecipientConfigError) {
+      return NextResponse.json(
+        { error: err.message, ...(err.code ? { code: err.code } : {}) },
+        { status: err.status }
+      );
+    }
+
+    console.error("[PATCH /api/items/[itemId]]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-
-  const updated = await prisma.inventoryItem.update({
-    where: { id: itemId },
-    data: {
-      ...rest,
-      imageUrl: rest.imageUrl !== undefined ? rest.imageUrl || null : undefined,
-      ...(rest.scanAcknowledgement !== undefined && {
-        scanAcknowledgement: scanAcknowledgement || null,
-      }),
-      // Prisma requires Prisma.JsonNull instead of plain null for nullable JSON fields
-      ...(labelLayout !== undefined && {
-        labelLayout: labelLayout === null ? Prisma.JsonNull : labelLayout,
-      }),
-    },
-  });
-
-  return NextResponse.json(updated);
 }
 
 export async function DELETE(_req: NextRequest, { params }: Params) {

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -3,6 +3,10 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { createItemSchema } from "@/lib/validations/item";
 import { canCreateItem } from "@/lib/tier";
+import {
+  RecipientConfigError,
+  resolveRecipientWritePayload,
+} from "@/lib/alert-recipients";
 
 export async function GET() {
   const session = await auth();
@@ -59,18 +63,54 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const item = await prisma.inventoryItem.create({
-      data: {
-        ...parsed.data,
-        imageUrl: parsed.data.imageUrl || null,
-        scanCooldownMinutes: session.user.tier === "PRO" ? scanCooldownMinutes : 60,
-        scanAcknowledgement: session.user.tier === "PRO" ? scanAcknowledgement || null : null,
+    const item = await prisma.$transaction(async (tx) => {
+      const resolvedRecipients = await resolveRecipientWritePayload({
+        tx,
         userId: session.user.id,
-      },
+        tier: session.user.tier,
+        alertEmail: parsed.data.alertEmail,
+        alertRecipients: parsed.data.alertRecipients,
+      });
+
+      const alertsEnabled = parsed.data.alertEmailEnabled ?? true;
+      if (alertsEnabled && resolvedRecipients.effectiveRecipientCount === 0) {
+        throw new RecipientConfigError(
+          "At least one email-enabled recipient is required while alerts are enabled."
+        );
+      }
+
+      const createdItem = await tx.inventoryItem.create({
+        data: {
+          name: parsed.data.name,
+          description: parsed.data.description,
+          imageUrl: parsed.data.imageUrl || null,
+          alertEmail: resolvedRecipients.primaryAlertEmail,
+          lowStockThreshold: parsed.data.lowStockThreshold,
+          alertEmailEnabled: parsed.data.alertEmailEnabled,
+          scanCooldownMinutes: session.user.tier === "PRO" ? scanCooldownMinutes : 60,
+          scanAcknowledgement: session.user.tier === "PRO" ? scanAcknowledgement || null : null,
+          userId: session.user.id,
+        },
+      });
+
+      await tx.inventoryItemRecipient.createMany({
+        data: resolvedRecipients.recipients.map((recipient) => ({
+          ...recipient,
+          itemId: createdItem.id,
+        })),
+      });
+
+      return createdItem;
     });
 
     return NextResponse.json(item, { status: 201 });
   } catch (err) {
+    if (err instanceof RecipientConfigError) {
+      return NextResponse.json(
+        { error: err.message, ...(err.code ? { code: err.code } : {}) },
+        { status: err.status }
+      );
+    }
     console.error("[POST /api/items]", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/app/api/scan/[qrCodeId]/route.ts
+++ b/app/api/scan/[qrCodeId]/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { sendAlertEmail } from "@/lib/resend";
 import { publishStockingRequestEvent } from "@/lib/realtime";
 import { sendStockingPushNotification } from "@/lib/push";
+import { getEffectiveRecipientEmails } from "@/lib/alert-recipients";
 
 type Params = { params: Promise<{ qrCodeId: string }> };
 
@@ -39,6 +40,22 @@ export async function POST(_req: NextRequest, { params }: Params) {
 
   const item = await prisma.inventoryItem.findUnique({
     where: { qrCodeId },
+    include: {
+      alertRecipients: {
+        orderBy: { position: "asc" },
+        select: {
+          kind: true,
+          inlineEmail: true,
+          contact: {
+            select: {
+              id: true,
+              email: true,
+              emailEnabled: true,
+            },
+          },
+        },
+      },
+    },
   });
 
   if (!item) {
@@ -66,6 +83,33 @@ export async function POST(_req: NextRequest, { params }: Params) {
       createdAt: request.createdAt,
       emailSent: request.emailSent,
     });
+
+    return NextResponse.json({
+      alreadyNotified: false,
+      itemName: item.name,
+      acknowledgementMessage: scanAcknowledgement || defaultAcknowledgements.sent,
+    });
+  }
+
+  const effectiveRecipientEmails = getEffectiveRecipientEmails(item.alertRecipients);
+
+  if (effectiveRecipientEmails.length === 0) {
+    const request = await prisma.stockingRequest.create({
+      data: { itemId: item.id, emailSent: false },
+    });
+
+    void notifyStockingRequestCreated({
+      userId: item.userId,
+      itemId: item.id,
+      itemName: item.name,
+      requestId: request.id,
+      createdAt: request.createdAt,
+      emailSent: request.emailSent,
+    });
+
+    console.error(
+      `[POST /api/scan/${qrCodeId}] Item "${item.id}" has no effective alert recipients configured.`
+    );
 
     return NextResponse.json({
       alreadyNotified: false,
@@ -124,7 +168,7 @@ export async function POST(_req: NextRequest, { params }: Params) {
   });
 
   try {
-    await sendAlertEmail(item.alertEmail, item.name);
+    await sendAlertEmail(effectiveRecipientEmails, item.name);
   } catch (err) {
     console.error("Failed to send alert email:", err);
     // Don't fail the request if email fails — the stocking request was still created

--- a/components/items/AlertRecipientManager.tsx
+++ b/components/items/AlertRecipientManager.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { AlertContactOption, ItemRecipientDraft } from "./recipientTypes";
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}
+
+function makeId(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+export default function AlertRecipientManager({
+  contacts,
+  recipients,
+  onChange,
+  allowCustomRecipientEntry = true,
+}: {
+  contacts: AlertContactOption[];
+  recipients: ItemRecipientDraft[];
+  onChange: (recipients: ItemRecipientDraft[]) => void;
+  allowCustomRecipientEntry?: boolean;
+}) {
+  const [contactSearch, setContactSearch] = useState("");
+  const [inlineEmail, setInlineEmail] = useState("");
+  const [newContact, setNewContact] = useState({
+    name: "",
+    email: "",
+    cellPhone: "",
+    emailEnabled: true,
+    smsOptIn: false,
+  });
+  const [localError, setLocalError] = useState("");
+
+  const selectedContactIds = new Set(
+    recipients.flatMap((recipient) =>
+      recipient.kind === "CONTACT" ? [recipient.contactId] : []
+    )
+  );
+
+  const filteredContacts = useMemo(() => {
+    const query = contactSearch.trim().toLowerCase();
+    return contacts.filter((contact) => {
+      if (selectedContactIds.has(contact.id)) return false;
+      if (!query) return true;
+
+      return (
+        contact.name.toLowerCase().includes(query) ||
+        contact.email.toLowerCase().includes(query)
+      );
+    });
+  }, [contactSearch, contacts, selectedContactIds]);
+
+  function addContact(contactId: string) {
+    onChange([
+      ...recipients,
+      {
+        clientId: makeId("contact"),
+        kind: "CONTACT",
+        contactId,
+      },
+    ]);
+    setLocalError("");
+  }
+
+  function addInlineEmail() {
+    const email = inlineEmail.trim();
+    if (!email) return;
+    if (!isValidEmail(email)) {
+      setLocalError("Enter a valid one-off email address.");
+      return;
+    }
+
+    onChange([
+      ...recipients,
+      {
+        clientId: makeId("inline"),
+        kind: "INLINE_EMAIL",
+        email,
+      },
+    ]);
+    setInlineEmail("");
+    setLocalError("");
+  }
+
+  function addNewContact() {
+    if (!newContact.name.trim()) {
+      setLocalError("New contacts need a name.");
+      return;
+    }
+
+    if (!isValidEmail(newContact.email)) {
+      setLocalError("Enter a valid email for the new contact.");
+      return;
+    }
+
+    onChange([
+      ...recipients,
+      {
+        clientId: makeId("new"),
+        kind: "NEW_CONTACT",
+        name: newContact.name.trim(),
+        email: newContact.email.trim(),
+        cellPhone: newContact.cellPhone.trim(),
+        emailEnabled: newContact.emailEnabled,
+        smsOptIn: newContact.smsOptIn,
+      },
+    ]);
+    setNewContact({
+      name: "",
+      email: "",
+      cellPhone: "",
+      emailEnabled: true,
+      smsOptIn: false,
+    });
+    setLocalError("");
+  }
+
+  function removeRecipient(clientId: string) {
+    onChange(recipients.filter((recipient) => recipient.clientId !== clientId));
+  }
+
+  return (
+    <div className="space-y-4 rounded-xl border border-outline-variant p-4 bg-surface-container-low">
+      <div>
+        <p className="text-sm font-medium text-on-surface">Alert recipients</p>
+        <p className="text-xs text-outline mt-0.5">
+          {allowCustomRecipientEntry
+            ? "Add saved contacts, create a new contact inline, or add one-off email recipients."
+            : "Add saved contacts to this item."}
+        </p>
+      </div>
+
+      {localError && (
+        <div className="bg-error-container border border-error/20 text-on-error-container text-sm rounded-lg px-4 py-3">
+          {localError}
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {recipients.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-outline px-4 py-5 text-sm text-on-surface-variant">
+            No recipients selected yet.
+          </div>
+        ) : (
+          recipients.map((recipient) => {
+            if (recipient.kind === "CONTACT") {
+              const contact = contacts.find((entry) => entry.id === recipient.contactId);
+              if (!contact) return null;
+
+              return (
+                <div
+                  key={recipient.clientId}
+                  className="rounded-xl border border-outline-variant bg-surface-container-lowest px-4 py-3 flex items-start justify-between gap-3"
+                >
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="text-sm font-medium text-on-surface">{contact.name}</p>
+                      {!contact.emailEnabled && (
+                        <span className="inline-flex rounded-full bg-surface-container-high px-2 py-0.5 text-[10px] font-medium text-on-surface-variant">
+                          Email muted
+                        </span>
+                      )}
+                      {contact.smsOptIn && (
+                        <span className="inline-flex rounded-full bg-secondary-container/40 px-2 py-0.5 text-[10px] font-medium text-on-secondary-container">
+                          SMS opt-in
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-on-surface-variant mt-1">{contact.email}</p>
+                    <p className="text-xs text-on-surface-variant">
+                      Cell phone: {contact.cellPhone || "-"}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeRecipient(recipient.clientId)}
+                    className="rounded-full border border-outline px-3 py-1 text-xs text-on-surface hover:bg-surface-container-low transition-colors"
+                  >
+                    Remove
+                  </button>
+                </div>
+              );
+            }
+
+            if (recipient.kind === "INLINE_EMAIL") {
+              return (
+                <div
+                  key={recipient.clientId}
+                  className="rounded-xl border border-outline-variant bg-surface-container-lowest px-4 py-3 flex items-start justify-between gap-3"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-on-surface">{recipient.email}</p>
+                    <p className="text-xs text-on-surface-variant mt-1">
+                      One-off email recipient
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeRecipient(recipient.clientId)}
+                    className="rounded-full border border-outline px-3 py-1 text-xs text-on-surface hover:bg-surface-container-low transition-colors"
+                  >
+                    Remove
+                  </button>
+                </div>
+              );
+            }
+
+            return (
+              <div
+                key={recipient.clientId}
+                className="rounded-xl border border-outline-variant bg-surface-container-lowest px-4 py-3 flex items-start justify-between gap-3"
+              >
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-medium text-on-surface">{recipient.name}</p>
+                    <span className="inline-flex rounded-full bg-primary-fixed px-2 py-0.5 text-[10px] font-medium text-primary">
+                      New contact
+                    </span>
+                    {!recipient.emailEnabled && (
+                      <span className="inline-flex rounded-full bg-surface-container-high px-2 py-0.5 text-[10px] font-medium text-on-surface-variant">
+                        Email muted
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-on-surface-variant mt-1">{recipient.email}</p>
+                  <p className="text-xs text-on-surface-variant">
+                    Cell phone: {recipient.cellPhone || "-"}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => removeRecipient(recipient.clientId)}
+                  className="rounded-full border border-outline px-3 py-1 text-xs text-on-surface hover:bg-surface-container-low transition-colors"
+                >
+                  Remove
+                </button>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      <div className="space-y-3 rounded-xl border border-outline-variant bg-surface-container-lowest p-4">
+        <div>
+          <p className="text-sm font-medium text-on-surface">Add saved contact</p>
+          <p className="text-xs text-on-surface-variant mt-0.5">
+            Search your contact list and add existing recipients.
+          </p>
+        </div>
+        <input
+          type="text"
+          value={contactSearch}
+          onChange={(e) => setContactSearch(e.target.value)}
+          placeholder="Search contacts by name or email"
+          className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
+        />
+        <div className="max-h-52 overflow-auto space-y-2">
+          {filteredContacts.length === 0 ? (
+            <p className="text-xs text-on-surface-variant">No matching saved contacts.</p>
+          ) : (
+            filteredContacts.map((contact) => (
+              <button
+                key={contact.id}
+                type="button"
+                onClick={() => addContact(contact.id)}
+                className="w-full text-left rounded-xl border border-outline-variant px-3 py-2 hover:bg-surface-container-low transition-colors"
+              >
+                <span className="block text-sm font-medium text-on-surface">{contact.name}</span>
+                <span className="block text-xs text-on-surface-variant">{contact.email}</span>
+                {!contact.emailEnabled && (
+                  <span className="mt-1 inline-flex rounded-full bg-surface-container-high px-2 py-0.5 text-[10px] font-medium text-on-surface-variant">
+                    Email muted
+                  </span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+
+      {allowCustomRecipientEntry && (
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="space-y-3 rounded-xl border border-outline-variant bg-surface-container-lowest p-4">
+            <div>
+              <p className="text-sm font-medium text-on-surface">Add one-off email</p>
+              <p className="text-xs text-on-surface-variant mt-0.5">
+                Use this when you do not want to save the recipient as a shared contact.
+              </p>
+            </div>
+            <input
+              type="email"
+              value={inlineEmail}
+              onChange={(e) => setInlineEmail(e.target.value)}
+              placeholder="alerts@yourcompany.com"
+              className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
+            />
+            <button
+              type="button"
+              onClick={addInlineEmail}
+              className="rounded-full bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary-container transition-colors"
+            >
+              Add email
+            </button>
+          </div>
+
+          <div className="space-y-3 rounded-xl border border-outline-variant bg-surface-container-lowest p-4">
+            <div>
+              <p className="text-sm font-medium text-on-surface">Create new contact</p>
+              <p className="text-xs text-on-surface-variant mt-0.5">
+                This contact will be created when you save the item.
+              </p>
+            </div>
+
+            <input
+              type="text"
+              value={newContact.name}
+              onChange={(e) => setNewContact((prev) => ({ ...prev, name: e.target.value }))}
+              placeholder="Team member name"
+              className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
+            />
+            <input
+              type="email"
+              value={newContact.email}
+              onChange={(e) => setNewContact((prev) => ({ ...prev, email: e.target.value }))}
+              placeholder="teammate@yourcompany.com"
+              className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
+            />
+            <input
+              type="tel"
+              value={newContact.cellPhone}
+              onChange={(e) => setNewContact((prev) => ({ ...prev, cellPhone: e.target.value }))}
+              placeholder="Cell phone (optional)"
+              maxLength={30}
+              className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
+            />
+            <label className="flex items-center justify-between gap-3">
+              <span className="text-sm text-on-surface">Email enabled</span>
+              <input
+                type="checkbox"
+                checked={newContact.emailEnabled}
+                onChange={(e) => setNewContact((prev) => ({ ...prev, emailEnabled: e.target.checked }))}
+                className="h-4 w-4 accent-primary"
+              />
+            </label>
+            <label className="flex items-center justify-between gap-3">
+              <span className="text-sm text-on-surface">SMS opt-in</span>
+              <input
+                type="checkbox"
+                checked={newContact.smsOptIn}
+                onChange={(e) => setNewContact((prev) => ({ ...prev, smsOptIn: e.target.checked }))}
+                className="h-4 w-4 accent-primary"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={addNewContact}
+              className="rounded-full bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary-container transition-colors"
+            >
+              Queue new contact
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/items/ItemForm.tsx
+++ b/components/items/ItemForm.tsx
@@ -2,20 +2,46 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import type { InventoryItem, Tier } from "@prisma/client";
+import type { Tier } from "@prisma/client";
+import AlertRecipientManager from "./AlertRecipientManager";
+import type { AlertContactOption, ItemRecipientDraft } from "./recipientTypes";
+
+type EditableItem = {
+  id: string;
+  name: string;
+  description: string | null;
+  alertEmail: string;
+  imageUrl: string | null;
+  lowStockThreshold: number | null;
+  alertEmailEnabled: boolean;
+  scanCooldownMinutes: number;
+  scanAcknowledgement: string | null;
+  alertRecipients: ItemRecipientDraft[];
+};
 
 interface Props {
-  item?: InventoryItem;
+  item?: EditableItem;
   mode: "create" | "edit";
   currentTier: Tier;
+  contacts: AlertContactOption[];
+  hasLockedProRecipients?: boolean;
 }
 
-export default function ItemForm({ item, mode, currentTier }: Props) {
+export default function ItemForm({
+  item,
+  mode,
+  currentTier,
+  contacts,
+  hasLockedProRecipients = false,
+}: Props) {
   const router = useRouter();
   const isPro = currentTier === "PRO";
   const [name, setName] = useState(item?.name ?? "");
   const [description, setDescription] = useState(item?.description ?? "");
   const [alertEmail, setAlertEmail] = useState(item?.alertEmail ?? "");
+  const [recipients, setRecipients] = useState<ItemRecipientDraft[]>(
+    item?.alertRecipients ?? []
+  );
   const [imageUrl, setImageUrl] = useState(item?.imageUrl ?? "");
   const [lowStockThreshold, setLowStockThreshold] = useState(
     item?.lowStockThreshold != null ? String(item.lowStockThreshold) : ""
@@ -68,7 +94,36 @@ export default function ItemForm({ item, mode, currentTier }: Props) {
       const payload = {
         name,
         description: description || undefined,
-        alertEmail,
+        ...(isPro
+          ? {
+              alertRecipients: recipients.map((recipient) => {
+                if (recipient.kind === "CONTACT") {
+                  return {
+                    kind: "CONTACT" as const,
+                    contactId: recipient.contactId,
+                  };
+                }
+
+                if (recipient.kind === "INLINE_EMAIL") {
+                  return {
+                    kind: "INLINE_EMAIL" as const,
+                    email: recipient.email,
+                  };
+                }
+
+                return {
+                  kind: "NEW_CONTACT" as const,
+                  name: recipient.name,
+                  email: recipient.email,
+                  cellPhone: recipient.cellPhone || undefined,
+                  emailEnabled: recipient.emailEnabled,
+                  smsOptIn: recipient.smsOptIn,
+                };
+              }),
+            }
+          : hasLockedProRecipients
+            ? {}
+            : { alertEmail }),
         imageUrl: imageUrl || undefined,
         lowStockThreshold: threshold && !isNaN(threshold) ? threshold : null,
         alertEmailEnabled,
@@ -148,27 +203,73 @@ export default function ItemForm({ item, mode, currentTier }: Props) {
           Optional. Print this number on the label as a restock reminder.
         </p>
       </div>
-      <div>
-        <label className="block text-sm font-medium text-on-surface-variant mb-1">
-          Alert email <span className="text-error">*</span>
-        </label>
-        <input
-          type="email"
-          value={alertEmail}
-          onChange={(e) => setAlertEmail(e.target.value)}
-          required
-          className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
-          placeholder="alerts@yourcompany.com"
+
+      {isPro ? (
+        <AlertRecipientManager
+          contacts={contacts}
+          recipients={recipients}
+          onChange={setRecipients}
+          allowCustomRecipientEntry={mode === "create"}
         />
-        <p className="text-xs text-outline mt-1">
-          This address receives low stock alerts when the QR code is scanned.
-        </p>
-      </div>
-      <div className="flex items-center justify-between py-1">
+      ) : hasLockedProRecipients ? (
+        <div className="space-y-3 rounded-xl border border-outline-variant p-4 bg-surface-container-low">
+          <div>
+            <p className="text-sm font-medium text-on-surface">Alert recipients</p>
+            <p className="text-xs text-outline mt-0.5">
+              This item uses Pro multi-recipient alerts. Upgrade to Pro to edit them.
+            </p>
+          </div>
+          {item?.alertRecipients.map((recipient) => (
+            <div
+              key={recipient.clientId}
+              className="rounded-xl border border-outline-variant bg-surface-container-lowest px-4 py-3"
+            >
+              {recipient.kind === "CONTACT" ? (
+                (() => {
+                  const contact = contacts.find((entry) => entry.id === recipient.contactId);
+                  return (
+                    <>
+                      <p className="text-sm text-on-surface">
+                        {contact?.name ?? "Saved contact recipient"}
+                      </p>
+                      <p className="text-xs text-on-surface-variant mt-1">
+                        {contact?.email ?? "Recipient details are preserved until you upgrade."}
+                      </p>
+                    </>
+                  );
+                })()
+              ) : recipient.kind === "INLINE_EMAIL" ? (
+                <p className="text-sm text-on-surface">{recipient.email}</p>
+              ) : (
+                <p className="text-sm text-on-surface">{recipient.email}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
         <div>
-          <p className="text-sm font-medium text-on-surface">Alert emails</p>
+          <label className="block text-sm font-medium text-on-surface-variant mb-1">
+            Alert email <span className="text-error">*</span>
+          </label>
+          <input
+            type="email"
+            value={alertEmail}
+            onChange={(e) => setAlertEmail(e.target.value)}
+            required
+            className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
+            placeholder="alerts@yourcompany.com"
+          />
+          <p className="text-xs text-outline mt-1">
+            This address receives low stock alerts when the QR code is scanned.
+          </p>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between rounded-xl border border-outline-variant bg-surface-container-low px-4 py-3">
+        <div>
+          <p className="text-sm font-medium text-on-surface">Enable email notifications</p>
           <p className="text-xs text-outline mt-0.5">
-            Send an email when this item&apos;s QR code is scanned
+            Turn off all email delivery for this item without removing its recipients.
           </p>
         </div>
         <button
@@ -187,53 +288,48 @@ export default function ItemForm({ item, mode, currentTier }: Props) {
           />
         </button>
       </div>
-      <div className="space-y-4 rounded-xl border border-outline-variant p-4 bg-surface-container-low">
-        <div>
-          <p className="text-sm font-medium text-on-surface">Pro scan controls</p>
-          <p className="text-xs text-outline mt-0.5">
-            Configure per-item scan timeout and acknowledgement message.
-          </p>
-          {!isPro && (
-            <p className="text-xs text-secondary mt-1">
-              Upgrade to Pro to customize these settings.
+      {isPro && (
+        <div className="space-y-4 rounded-xl border border-outline-variant p-4 bg-surface-container-low">
+          <div>
+            <p className="text-sm font-medium text-on-surface">Pro scan controls</p>
+            <p className="text-xs text-outline mt-0.5">
+              Configure per-item scan timeout and acknowledgement message.
             </p>
-          )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-on-surface-variant mb-1">
+              Scan timeout (minutes)
+            </label>
+            <input
+              type="number"
+              value={scanCooldownMinutes}
+              onChange={(e) => setScanCooldownMinutes(e.target.value)}
+              min={1}
+              max={1440}
+              className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface"
+            />
+            <p className="text-xs text-outline mt-1">
+              How long to wait before another email alert can be sent for this item.
+            </p>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-on-surface-variant mb-1">
+              QR acknowledgement message
+            </label>
+            <textarea
+              value={scanAcknowledgement}
+              onChange={(e) => setScanAcknowledgement(e.target.value)}
+              rows={3}
+              maxLength={280}
+              placeholder="Thanks! We received your scan and notified the team."
+              className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface resize-none"
+            />
+            <p className="text-xs text-outline mt-1">
+              Optional. This replaces the default message shown after scanning.
+            </p>
+          </div>
         </div>
-        <div>
-          <label className="block text-sm font-medium text-on-surface-variant mb-1">
-            Scan timeout (minutes)
-          </label>
-          <input
-            type="number"
-            value={scanCooldownMinutes}
-            onChange={(e) => setScanCooldownMinutes(e.target.value)}
-            min={1}
-            max={1440}
-            disabled={!isPro}
-            className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface disabled:opacity-60"
-          />
-          <p className="text-xs text-outline mt-1">
-            How long to wait before another email alert can be sent for this item.
-          </p>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-on-surface-variant mb-1">
-            QR acknowledgement message
-          </label>
-          <textarea
-            value={scanAcknowledgement}
-            onChange={(e) => setScanAcknowledgement(e.target.value)}
-            rows={3}
-            maxLength={280}
-            disabled={!isPro}
-            placeholder="Thanks! We received your scan and notified the team."
-            className="w-full border border-outline rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary bg-surface-container-lowest text-on-surface resize-none disabled:opacity-60"
-          />
-          <p className="text-xs text-outline mt-1">
-            Optional. This replaces the default message shown after scanning.
-          </p>
-        </div>
-      </div>
+      )}
       <div>
         <label className="block text-sm font-medium text-on-surface-variant mb-1">
           Image (optional)
@@ -253,7 +349,7 @@ export default function ItemForm({ item, mode, currentTier }: Props) {
           className="block text-sm text-on-surface-variant file:mr-3 file:py-1.5 file:px-3 file:rounded file:border-0 file:text-xs file:font-medium file:bg-surface-container file:text-on-surface-variant hover:file:bg-surface-container-high"
         />
         {uploading && (
-          <p className="text-xs text-secondary mt-1">Uploading…</p>
+          <p className="text-xs text-secondary mt-1">Uploading...</p>
         )}
       </div>
       <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row">
@@ -264,11 +360,11 @@ export default function ItemForm({ item, mode, currentTier }: Props) {
         >
           {loading
             ? mode === "create"
-              ? "Creating…"
-              : "Saving…"
+              ? "Creating..."
+              : "Saving..."
             : mode === "create"
-            ? "Create item"
-            : "Save changes"}
+              ? "Create item"
+              : "Save changes"}
         </button>
         <button
           type="button"

--- a/components/items/recipientTypes.ts
+++ b/components/items/recipientTypes.ts
@@ -1,0 +1,29 @@
+export type AlertContactOption = {
+  id: string;
+  name: string;
+  email: string;
+  cellPhone: string | null;
+  emailEnabled: boolean;
+  smsOptIn: boolean;
+};
+
+export type ItemRecipientDraft =
+  | {
+      clientId: string;
+      kind: "CONTACT";
+      contactId: string;
+    }
+  | {
+      clientId: string;
+      kind: "INLINE_EMAIL";
+      email: string;
+    }
+  | {
+      clientId: string;
+      kind: "NEW_CONTACT";
+      name: string;
+      email: string;
+      cellPhone: string;
+      emailEnabled: boolean;
+      smsOptIn: boolean;
+    };

--- a/components/layout/BottomNav.tsx
+++ b/components/layout/BottomNav.tsx
@@ -2,16 +2,22 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type { Tier } from "@prisma/client";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: "dashboard" },
   { href: "/items", label: "Inventory", icon: "inventory_2" },
+  { href: "/contacts", label: "Contacts", icon: "groups" },
   { href: "/requests", label: "Requests", icon: "notifications" },
   { href: "/settings", label: "Settings", icon: "settings" },
 ];
 
-export default function BottomNav() {
+export default function BottomNav({ currentTier }: { currentTier: Tier }) {
   const pathname = usePathname();
+  const visibleNavItems =
+    currentTier === "PRO"
+      ? navItems
+      : navItems.filter((item) => item.href !== "/contacts");
 
   return (
     <nav
@@ -19,7 +25,7 @@ export default function BottomNav() {
       className="fixed bottom-0 inset-x-0 z-50 md:hidden bg-white/60 backdrop-blur-xl rounded-t-3xl pb-[env(safe-area-inset-bottom)]"
     >
       <div className="flex">
-        {navItems.map((item) => {
+        {visibleNavItems.map((item) => {
           const active =
             pathname === item.href ||
             (item.href !== "/dashboard" && pathname.startsWith(item.href));

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -3,16 +3,22 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
+import type { Tier } from "@prisma/client";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: "dashboard" },
   { href: "/items", label: "Inventory", icon: "inventory_2" },
+  { href: "/contacts", label: "Contacts", icon: "groups" },
   { href: "/requests", label: "Stocking Requests", icon: "notifications" },
   { href: "/settings", label: "Settings", icon: "settings" },
 ];
 
-export default function Sidebar() {
+export default function Sidebar({ currentTier }: { currentTier: Tier }) {
   const pathname = usePathname();
+  const visibleNavItems =
+    currentTier === "PRO"
+      ? navItems
+      : navItems.filter((item) => item.href !== "/contacts");
 
   return (
     <aside className="hidden md:flex w-60 bg-surface-container-lowest border-r border-outline-variant flex-col min-h-screen">
@@ -20,7 +26,7 @@ export default function Sidebar() {
         <span className="font-headline font-bold text-primary text-lg">InventoryAlert</span>
       </div>
       <nav className="flex-1 px-3 py-4 space-y-1">
-        {navItems.map((item) => {
+        {visibleNavItems.map((item) => {
           const active =
             pathname === item.href ||
             (item.href !== "/dashboard" && pathname.startsWith(item.href));

--- a/lib/alert-recipients.ts
+++ b/lib/alert-recipients.ts
@@ -1,0 +1,406 @@
+import { Prisma, RecipientKind, type Tier } from "@prisma/client";
+import type { AlertContactInput } from "@/lib/validations/contact";
+import type { ItemAlertRecipientInput } from "@/lib/validations/item";
+
+type Tx = Prisma.TransactionClient;
+
+type ContactRecipientSnapshot = {
+  id: string;
+  email: string;
+  emailEnabled: boolean;
+};
+
+type RecipientSnapshot = {
+  kind: RecipientKind;
+  inlineEmail: string | null;
+  contact: ContactRecipientSnapshot | null;
+};
+
+export class RecipientConfigError extends Error {
+  status: number;
+  code?: string;
+
+  constructor(message: string, status = 400, code?: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function cleanEmail(email: string): string {
+  return email.trim();
+}
+
+export function cleanOptionalText(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function isProTier(tier: Tier): boolean {
+  return tier === "PRO";
+}
+
+function dedupeEmails(emails: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const email of emails) {
+    const cleaned = cleanEmail(email);
+    const normalized = normalizeEmail(cleaned);
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    unique.push(cleaned);
+  }
+
+  return unique;
+}
+
+export function getConfiguredRecipientEmails(
+  recipients: RecipientSnapshot[]
+): string[] {
+  return dedupeEmails(
+    recipients.flatMap((recipient) => {
+      if (recipient.kind === RecipientKind.CONTACT && recipient.contact?.email) {
+        return [recipient.contact.email];
+      }
+
+      if (recipient.kind === RecipientKind.INLINE_EMAIL && recipient.inlineEmail) {
+        return [recipient.inlineEmail];
+      }
+
+      return [];
+    })
+  );
+}
+
+export function getEffectiveRecipientEmails(
+  recipients: RecipientSnapshot[]
+): string[] {
+  return dedupeEmails(
+    recipients.flatMap((recipient) => {
+      if (recipient.kind === RecipientKind.CONTACT) {
+        if (recipient.contact?.emailEnabled && recipient.contact.email) {
+          return [recipient.contact.email];
+        }
+
+        return [];
+      }
+
+      if (recipient.kind === RecipientKind.INLINE_EMAIL && recipient.inlineEmail) {
+        return [recipient.inlineEmail];
+      }
+
+      return [];
+    })
+  );
+}
+
+export function getPrimaryRecipientEmail(
+  recipients: RecipientSnapshot[],
+  fallbackEmail?: string | null
+): string {
+  const effectiveEmails = getEffectiveRecipientEmails(recipients);
+  if (effectiveEmails.length > 0) return effectiveEmails[0];
+
+  const configuredEmails = getConfiguredRecipientEmails(recipients);
+  if (configuredEmails.length > 0) return configuredEmails[0];
+
+  const fallback = cleanOptionalText(fallbackEmail);
+  if (fallback) return fallback;
+
+  throw new RecipientConfigError("At least one alert recipient is required.");
+}
+
+export function normalizeContactInput(input: AlertContactInput) {
+  const email = cleanEmail(input.email);
+  return {
+    name: input.name.trim(),
+    email,
+    emailNormalized: normalizeEmail(email),
+    cellPhone: cleanOptionalText(input.cellPhone),
+    emailEnabled: input.emailEnabled ?? true,
+    smsOptIn: input.smsOptIn ?? false,
+  };
+}
+
+type ResolvedRecipientWrite = {
+  recipients: Array<{
+    kind: RecipientKind;
+    contactId: string | null;
+    inlineEmail: string | null;
+    inlineEmailNormalized: string | null;
+    position: number;
+  }>;
+  primaryAlertEmail: string;
+  effectiveRecipientCount: number;
+};
+
+export async function resolveRecipientWritePayload(args: {
+  tx: Tx;
+  userId: string;
+  tier: Tier;
+  alertEmail?: string | null;
+  alertRecipients?: ItemAlertRecipientInput[];
+  fallbackAlertEmail?: string | null;
+}) {
+  const { tx, userId, tier, fallbackAlertEmail } = args;
+
+  if (!isProTier(tier)) {
+    if (args.alertRecipients && args.alertRecipients.length > 0) {
+      throw new RecipientConfigError(
+        "Multiple alert recipients are a Pro feature.",
+        403,
+        "PRO_FEATURE_REQUIRED"
+      );
+    }
+
+    const alertEmail = cleanOptionalText(args.alertEmail);
+    if (!alertEmail) {
+      throw new RecipientConfigError("Alert email is required.");
+    }
+
+    return {
+      recipients: [
+        {
+          kind: RecipientKind.INLINE_EMAIL,
+          contactId: null,
+          inlineEmail: alertEmail,
+          inlineEmailNormalized: normalizeEmail(alertEmail),
+          position: 0,
+        },
+      ],
+      primaryAlertEmail: alertEmail,
+      effectiveRecipientCount: 1,
+    } satisfies ResolvedRecipientWrite;
+  }
+
+  const requestedRecipients =
+    args.alertRecipients && args.alertRecipients.length > 0
+      ? args.alertRecipients
+      : args.alertEmail
+        ? [{ kind: "INLINE_EMAIL", email: args.alertEmail } satisfies ItemAlertRecipientInput]
+        : [];
+
+  if (requestedRecipients.length === 0) {
+    throw new RecipientConfigError("At least one alert recipient is required.");
+  }
+
+  const contactIds = requestedRecipients.flatMap((recipient) =>
+    recipient.kind === "CONTACT" ? [recipient.contactId] : []
+  );
+
+  const existingContacts =
+    contactIds.length > 0
+      ? await tx.alertContact.findMany({
+          where: {
+            userId,
+            id: { in: Array.from(new Set(contactIds)) },
+          },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            emailNormalized: true,
+            cellPhone: true,
+            emailEnabled: true,
+            smsOptIn: true,
+          },
+        })
+      : [];
+
+  const contactById = new Map(existingContacts.map((contact) => [contact.id, contact]));
+  if (contactById.size !== new Set(contactIds).size) {
+    throw new RecipientConfigError("One or more selected contacts no longer exist.", 404);
+  }
+
+  const newContactInputs = requestedRecipients
+    .filter((recipient): recipient is Extract<ItemAlertRecipientInput, { kind: "NEW_CONTACT" }> => recipient.kind === "NEW_CONTACT")
+    .map((recipient) => normalizeContactInput({
+      name: recipient.name,
+      email: recipient.email,
+      cellPhone: recipient.cellPhone,
+      emailEnabled: recipient.emailEnabled,
+      smsOptIn: recipient.smsOptIn,
+    }));
+
+  const newContactEmailNormalized = Array.from(
+    new Set(newContactInputs.map((contact) => contact.emailNormalized))
+  );
+
+  const existingByNormalized =
+    newContactEmailNormalized.length > 0
+      ? await tx.alertContact.findMany({
+          where: {
+            userId,
+            emailNormalized: { in: newContactEmailNormalized },
+          },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            emailNormalized: true,
+            cellPhone: true,
+            emailEnabled: true,
+            smsOptIn: true,
+          },
+        })
+      : [];
+
+  const contactByNormalized = new Map(
+    [...existingContacts, ...existingByNormalized].map((contact) => [
+      contact.emailNormalized,
+      contact,
+    ])
+  );
+
+  const createdContactByNormalized = new Map<string, ContactRecipientSnapshot>();
+  const recipients: ResolvedRecipientWrite["recipients"] = [];
+  const configuredEmails: string[] = [];
+  const effectiveEmails: string[] = [];
+  const seenRecipientKeys = new Set<string>();
+
+  for (const requestedRecipient of requestedRecipients) {
+    if (requestedRecipient.kind === "INLINE_EMAIL") {
+      const email = cleanEmail(requestedRecipient.email);
+      const normalized = normalizeEmail(email);
+      const recipientKey = `INLINE_EMAIL:${normalized}`;
+      if (seenRecipientKeys.has(recipientKey)) continue;
+      seenRecipientKeys.add(recipientKey);
+      configuredEmails.push(email);
+      effectiveEmails.push(email);
+      recipients.push({
+        kind: RecipientKind.INLINE_EMAIL,
+        contactId: null,
+        inlineEmail: email,
+        inlineEmailNormalized: normalized,
+        position: recipients.length,
+      });
+      continue;
+    }
+
+    let contact: ContactRecipientSnapshot | undefined;
+
+    if (requestedRecipient.kind === "CONTACT") {
+      const existing = contactById.get(requestedRecipient.contactId);
+      if (!existing) {
+        throw new RecipientConfigError("One or more selected contacts no longer exist.", 404);
+      }
+
+      contact = {
+        id: existing.id,
+        email: existing.email,
+        emailEnabled: existing.emailEnabled,
+      };
+    } else {
+      const normalizedInput = normalizeContactInput({
+        name: requestedRecipient.name,
+        email: requestedRecipient.email,
+        cellPhone: requestedRecipient.cellPhone,
+        emailEnabled: requestedRecipient.emailEnabled,
+        smsOptIn: requestedRecipient.smsOptIn,
+      });
+
+      const existing = contactByNormalized.get(normalizedInput.emailNormalized);
+      if (existing) {
+        contact = {
+          id: existing.id,
+          email: existing.email,
+          emailEnabled: existing.emailEnabled,
+        };
+      } else {
+        const cached = createdContactByNormalized.get(normalizedInput.emailNormalized);
+        if (cached) {
+          contact = cached;
+        } else {
+          const created = await tx.alertContact.create({
+            data: {
+              userId,
+              ...normalizedInput,
+            },
+            select: {
+              id: true,
+              email: true,
+              emailEnabled: true,
+            },
+          });
+
+          createdContactByNormalized.set(normalizedInput.emailNormalized, created);
+          contact = created;
+        }
+      }
+    }
+
+    const recipientKey = `CONTACT:${contact.id}`;
+    if (seenRecipientKeys.has(recipientKey)) continue;
+    seenRecipientKeys.add(recipientKey);
+    configuredEmails.push(contact.email);
+    if (contact.emailEnabled) {
+      effectiveEmails.push(contact.email);
+    }
+    recipients.push({
+      kind: RecipientKind.CONTACT,
+      contactId: contact.id,
+      inlineEmail: null,
+      inlineEmailNormalized: null,
+      position: recipients.length,
+    });
+  }
+
+  const primaryAlertEmail =
+    effectiveEmails[0] ??
+    configuredEmails[0] ??
+    cleanOptionalText(fallbackAlertEmail) ??
+    (() => {
+      throw new RecipientConfigError("At least one alert recipient is required.");
+    })();
+
+  return {
+    recipients,
+    primaryAlertEmail,
+    effectiveRecipientCount: dedupeEmails(effectiveEmails).length,
+  } satisfies ResolvedRecipientWrite;
+}
+
+export async function refreshItemAlertEmailMirrors(
+  tx: Tx,
+  itemIds: string[]
+): Promise<void> {
+  const uniqueItemIds = Array.from(new Set(itemIds.filter(Boolean)));
+  if (uniqueItemIds.length === 0) return;
+
+  const items = await tx.inventoryItem.findMany({
+    where: { id: { in: uniqueItemIds } },
+    select: {
+      id: true,
+      alertEmail: true,
+      alertRecipients: {
+        orderBy: { position: "asc" },
+        select: {
+          kind: true,
+          inlineEmail: true,
+          contact: {
+            select: {
+              id: true,
+              email: true,
+              emailEnabled: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  for (const item of items) {
+    const nextAlertEmail = getPrimaryRecipientEmail(item.alertRecipients, item.alertEmail);
+    if (nextAlertEmail === item.alertEmail) continue;
+
+    await tx.inventoryItem.update({
+      where: { id: item.id },
+      data: { alertEmail: nextAlertEmail },
+    });
+  }
+}

--- a/lib/resend.ts
+++ b/lib/resend.ts
@@ -21,7 +21,7 @@ export async function sendPasswordResetEmail(to: string, resetUrl: string): Prom
   });
 }
 
-export async function sendAlertEmail(to: string, itemName: string): Promise<void> {
+export async function sendAlertEmail(to: string | string[], itemName: string): Promise<void> {
   const now = new Date().toLocaleString("en-US", { timeZone: "UTC" });
   await resend.emails.send({
     from: process.env.RESEND_FROM_EMAIL!,

--- a/lib/validations/contact.ts
+++ b/lib/validations/contact.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+const optionalTrimmedString = z.string().trim().optional().or(z.literal(""));
+
+export const alertContactSchema = z.object({
+  name: z.string().trim().min(1, "Name is required").max(100),
+  email: z.string().trim().email("Must be a valid email address"),
+  cellPhone: optionalTrimmedString
+    .transform((value) => value?.trim() || undefined)
+    .refine((value) => !value || value.length <= 30, "Cell phone must be 30 characters or fewer"),
+  emailEnabled: z.boolean().optional(),
+  smsOptIn: z.boolean().optional(),
+});
+
+export const updateAlertContactSchema = alertContactSchema.partial();
+
+export type AlertContactInput = z.infer<typeof alertContactSchema>;
+export type UpdateAlertContactInput = z.infer<typeof updateAlertContactSchema>;

--- a/lib/validations/item.ts
+++ b/lib/validations/item.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { alertContactSchema } from "./contact";
 
 const textElementSchema = z.object({
   id: z.string(),
@@ -19,11 +20,31 @@ export const createItemSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
   description: z.string().max(500).optional(),
   imageUrl: z.string().url().optional().or(z.literal("")),
-  alertEmail: z.string().email("Must be a valid email address"),
+  alertEmail: z.string().trim().email("Must be a valid email address").optional(),
   lowStockThreshold: z.number().int().min(1).max(9999).nullable().optional(),
   alertEmailEnabled: z.boolean().optional(),
   scanCooldownMinutes: z.number().int().min(1).max(1440).optional(),
   scanAcknowledgement: z.string().max(280).optional(),
+  alertRecipients: z.array(
+    z.discriminatedUnion("kind", [
+      z.object({
+        kind: z.literal("CONTACT"),
+        contactId: z.string().min(1),
+      }),
+      z.object({
+        kind: z.literal("INLINE_EMAIL"),
+        email: z.string().trim().email("Must be a valid email address"),
+      }),
+      z.object({
+        kind: z.literal("NEW_CONTACT"),
+        name: alertContactSchema.shape.name,
+        email: alertContactSchema.shape.email,
+        cellPhone: alertContactSchema.shape.cellPhone,
+        emailEnabled: z.boolean().optional(),
+        smsOptIn: z.boolean().optional(),
+      }),
+    ])
+  ).optional(),
 });
 
 export const updateItemSchema = createItemSchema.partial().extend({
@@ -33,3 +54,4 @@ export const updateItemSchema = createItemSchema.partial().extend({
 export type CreateItemInput = z.infer<typeof createItemSchema>;
 export type UpdateItemInput = z.infer<typeof updateItemSchema>;
 export type LabelLayoutInput = z.infer<typeof labelLayoutSchema>;
+export type ItemAlertRecipientInput = NonNullable<CreateItemInput["alertRecipients"]>[number];

--- a/prisma/migrations/20260419170000_add_alert_contacts_and_recipients/migration.sql
+++ b/prisma/migrations/20260419170000_add_alert_contacts_and_recipients/migration.sql
@@ -1,0 +1,100 @@
+-- CreateEnum
+CREATE TYPE "RecipientKind" AS ENUM ('CONTACT', 'INLINE_EMAIL');
+
+-- CreateTable
+CREATE TABLE "AlertContact" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "emailNormalized" TEXT NOT NULL,
+    "cellPhone" TEXT,
+    "emailEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "smsOptIn" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AlertContact_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "InventoryItemRecipient" (
+    "id" TEXT NOT NULL,
+    "itemId" TEXT NOT NULL,
+    "kind" "RecipientKind" NOT NULL,
+    "contactId" TEXT,
+    "inlineEmail" TEXT,
+    "inlineEmailNormalized" TEXT,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "InventoryItemRecipient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AlertContact_userId_emailNormalized_key" ON "AlertContact"("userId", "emailNormalized");
+
+-- CreateIndex
+CREATE INDEX "AlertContact_userId_idx" ON "AlertContact"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InventoryItemRecipient_itemId_contactId_key" ON "InventoryItemRecipient"("itemId", "contactId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InventoryItemRecipient_itemId_inlineEmailNormalized_key" ON "InventoryItemRecipient"("itemId", "inlineEmailNormalized");
+
+-- CreateIndex
+CREATE INDEX "InventoryItemRecipient_itemId_idx" ON "InventoryItemRecipient"("itemId");
+
+-- CreateIndex
+CREATE INDEX "InventoryItemRecipient_contactId_idx" ON "InventoryItemRecipient"("contactId");
+
+-- AddForeignKey
+ALTER TABLE "AlertContact" ADD CONSTRAINT "AlertContact_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InventoryItemRecipient" ADD CONSTRAINT "InventoryItemRecipient_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "InventoryItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InventoryItemRecipient" ADD CONSTRAINT "InventoryItemRecipient_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "AlertContact"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddCheckConstraint
+ALTER TABLE "InventoryItemRecipient"
+ADD CONSTRAINT "InventoryItemRecipient_kind_shape_check"
+CHECK (
+  (
+    "kind" = 'CONTACT'
+    AND "contactId" IS NOT NULL
+    AND "inlineEmail" IS NULL
+    AND "inlineEmailNormalized" IS NULL
+  )
+  OR (
+    "kind" = 'INLINE_EMAIL'
+    AND "contactId" IS NULL
+    AND "inlineEmail" IS NOT NULL
+    AND "inlineEmailNormalized" IS NOT NULL
+  )
+);
+
+-- Backfill one inline recipient per existing item using the current alertEmail
+INSERT INTO "InventoryItemRecipient" (
+    "id",
+    "itemId",
+    "kind",
+    "inlineEmail",
+    "inlineEmailNormalized",
+    "position",
+    "createdAt",
+    "updatedAt"
+)
+SELECT
+    'backfill_' || md5("id" || ':' || "alertEmail"),
+    "id",
+    'INLINE_EMAIL'::"RecipientKind",
+    "alertEmail",
+    lower(trim("alertEmail")),
+    0,
+    "createdAt",
+    "updatedAt"
+FROM "InventoryItem";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,11 @@ enum ExternalPlatform {
   OTHER
 }
 
+enum RecipientKind {
+  CONTACT
+  INLINE_EMAIL
+}
+
 model User {
   id                     String          @id @default(cuid())
   email                  String          @unique
@@ -41,6 +46,7 @@ model User {
   updatedAt              DateTime        @updatedAt
 
   items                  InventoryItem[]
+  contacts               AlertContact[]
   pushSubscriptions      PushSubscription[]
 }
 
@@ -85,10 +91,50 @@ model InventoryItem {
   updatedAt         DateTime          @updatedAt
 
   user              User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  alertRecipients   InventoryItemRecipient[]
   stockingRequests  StockingRequest[]
 
   @@index([userId])
   @@index([qrCodeId])
+}
+
+model AlertContact {
+  id              String                   @id @default(cuid())
+  userId          String
+  name            String
+  email           String
+  emailNormalized String
+  cellPhone       String?
+  emailEnabled    Boolean                  @default(true)
+  smsOptIn        Boolean                  @default(false)
+  createdAt       DateTime                 @default(now())
+  updatedAt       DateTime                 @updatedAt
+
+  user            User                     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  itemRecipients  InventoryItemRecipient[]
+
+  @@unique([userId, emailNormalized])
+  @@index([userId])
+}
+
+model InventoryItemRecipient {
+  id                    String         @id @default(cuid())
+  itemId                String
+  kind                  RecipientKind
+  contactId             String?
+  inlineEmail           String?
+  inlineEmailNormalized String?
+  position              Int            @default(0)
+  createdAt             DateTime       @default(now())
+  updatedAt             DateTime       @updatedAt
+
+  item                  InventoryItem  @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  contact               AlertContact?  @relation(fields: [contactId], references: [id], onDelete: Cascade)
+
+  @@unique([itemId, contactId])
+  @@unique([itemId, inlineEmailNormalized])
+  @@index([itemId])
+  @@index([contactId])
 }
 
 model StockingRequest {


### PR DESCRIPTION
## Summary
- add Pro contacts management and item-level multi-recipient alert delivery
- update item creation/editing flows for saved contacts, inline recipients, and recipient preferences
- hide Pro-only navigation and scan controls from Free users while keeping backend gating in place

## Testing
- `next build`
- `tsc --noEmit`
