### PR TITLE
Add Google auth and harden signup validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@ DATABASE_URL="postgresql://user:password@localhost:5432/inventoryalert"
 # NextAuth
 NEXTAUTH_SECRET="replace-with-32-char-random-secret"
 NEXTAUTH_URL="http://localhost:3000"
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+# Google OAuth callback URL for local development:
+# http://localhost:3000/api/auth/callback/google
 
 # Public base URL (used for QR code URL construction)
 NEXT_PUBLIC_BASE_URL="http://localhost:3000"

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 
-export default function ForgotPasswordPage() {
+function ForgotPasswordForm() {
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl");
+  const loginHref = callbackUrl
+    ? `/login?callbackUrl=${encodeURIComponent(callbackUrl)}`
+    : "/login";
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [submitted, setSubmitted] = useState(false);
@@ -32,56 +38,68 @@ export default function ForgotPasswordPage() {
     }
   }
 
+  if (submitted) {
+    return (
+      <div className="text-center space-y-4">
+        <div className="bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-4 py-3">
+          If an account exists for <strong>{email}</strong>, a reset link has been sent. Check your inbox.
+        </div>
+        <Link href={loginHref} className="block text-sm text-blue-600 hover:underline">
+          Back to sign in
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+          {error}
+        </div>
+      )}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Email address
+        </label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+      >
+        {loading ? "Sending..." : "Send reset link"}
+      </button>
+      <p className="text-center text-sm text-gray-500">
+        <Link href={loginHref} className="text-blue-600 hover:underline">
+          Back to sign in
+        </Link>
+      </p>
+    </form>
+  );
+}
+
+export default function ForgotPasswordPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
       <div className="w-full max-w-md bg-white rounded-2xl shadow-sm border border-gray-200 p-6 sm:p-8">
         <div className="mb-8 text-center">
           <h1 className="text-2xl font-bold text-gray-900">InventoryAlert</h1>
           <p className="text-gray-500 mt-1 text-sm">Reset your password</p>
+          <p className="text-gray-400 mt-2 text-xs">
+            Use the email tied to your account, including accounts that started with Google sign-in.
+          </p>
         </div>
-
-        {submitted ? (
-          <div className="text-center space-y-4">
-            <div className="bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-4 py-3">
-              If an account exists for <strong>{email}</strong>, a reset link has been sent. Check your inbox.
-            </div>
-            <Link href="/login" className="block text-sm text-blue-600 hover:underline">
-              Back to sign in
-            </Link>
-          </div>
-        ) : (
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {error && (
-              <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
-                {error}
-              </div>
-            )}
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Email address
-              </label>
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-            </div>
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
-            >
-              {loading ? "Sending…" : "Send reset link"}
-            </button>
-            <p className="text-center text-sm text-gray-500">
-              <Link href="/login" className="text-blue-600 hover:underline">
-                Back to sign in
-              </Link>
-            </p>
-          </form>
-        )}
+        <Suspense>
+          <ForgotPasswordForm />
+        </Suspense>
       </div>
     </div>
   );

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,90 +1,194 @@
 "use client";
 
-import { useState, Suspense } from "react";
-import { signIn } from "next-auth/react";
+import { Suspense, useEffect, useState } from "react";
+import { getProviders, signIn } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
+import { GoogleSignInButton } from "@/components/auth/GoogleSignInButton";
+import { GOOGLE_SIGNIN_REQUIRED_CODE } from "@/lib/auth-errors";
+
+function Divider() {
+  return (
+    <div className="relative">
+      <div className="absolute inset-0 flex items-center">
+        <div className="w-full border-t border-gray-200" />
+      </div>
+      <div className="relative flex justify-center text-xs uppercase tracking-wide text-gray-400">
+        <span className="bg-white px-3">Or continue with email</span>
+      </div>
+    </div>
+  );
+}
 
 function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") ?? "/dashboard";
   const passwordReset = searchParams.get("reset") === "1";
+  const registered = searchParams.get("registered") === "1";
+  const registerHref =
+    callbackUrl === "/dashboard"
+      ? "/register"
+      : `/register?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+  const forgotPasswordHref =
+    callbackUrl === "/dashboard"
+      ? "/forgot-password"
+      : `/forgot-password?callbackUrl=${encodeURIComponent(callbackUrl)}`;
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [googleOnlyError, setGoogleOnlyError] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
+  const [googleEnabled, setGoogleEnabled] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    getProviders()
+      .then((providers) => {
+        if (active) {
+          setGoogleEnabled(Boolean(providers?.google));
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setGoogleEnabled(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  async function handleGoogleSignIn() {
+    setError("");
+    setGoogleOnlyError(false);
+    setGoogleLoading(true);
+
+    try {
+      await signIn("google", { redirectTo: callbackUrl });
+    } finally {
+      setGoogleLoading(false);
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
+    setGoogleOnlyError(false);
     setLoading(true);
+
     const result = await signIn("credentials", {
       email,
       password,
       redirect: false,
+      redirectTo: callbackUrl,
     });
+
     setLoading(false);
+
     if (result?.error) {
+      if (result.code === GOOGLE_SIGNIN_REQUIRED_CODE) {
+        setGoogleOnlyError(true);
+        setError(
+          "This account uses Google sign-in. Continue with Google or use Forgot password to create a password."
+        );
+        return;
+      }
+
       setError("Invalid email or password.");
-    } else {
-      router.push("/dashboard");
+      return;
     }
+
+    router.push(result?.url ?? callbackUrl);
   }
 
   return (
     <>
+      {registered && (
+        <div className="bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-4 py-3 mb-4">
+          Account created. Sign in to continue.
+        </div>
+      )}
       {passwordReset && (
         <div className="bg-green-50 border border-green-200 text-green-700 text-sm rounded-lg px-4 py-3 mb-4">
           Password updated. You can now sign in with your new password.
         </div>
       )}
-      <form onSubmit={handleSubmit} className="space-y-4">
-        {error && (
-          <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
-            {error}
-          </div>
+
+      <div className="space-y-4">
+        {googleEnabled && (
+          <>
+            <GoogleSignInButton
+              label={googleLoading ? "Connecting to Google..." : "Continue with Google"}
+              disabled={loading || googleLoading}
+              onClick={handleGoogleSignIn}
+            />
+            <Divider />
+          </>
         )}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Email
-          </label>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Password
-          </label>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-          <div className="text-right mt-1">
-            <Link href="/forgot-password" className="text-xs text-blue-600 hover:underline">
-              Forgot password?
-            </Link>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+              <p>{error}</p>
+              {googleOnlyError && (
+                <p className="mt-2">
+                  <Link
+                    href={forgotPasswordHref}
+                    className="font-medium text-red-700 underline"
+                  >
+                    Send yourself a password setup link
+                  </Link>
+                </p>
+              )}
+            </div>
+          )}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Email
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
           </div>
-        </div>
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
-        >
-          {loading ? "Signing in…" : "Sign in"}
-        </button>
-      </form>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Password
+            </label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <div className="text-right mt-1">
+              <Link href={forgotPasswordHref} className="text-xs text-blue-600 hover:underline">
+                Forgot password?
+              </Link>
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={loading || googleLoading}
+            className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {loading ? "Signing in..." : "Sign in"}
+          </button>
+        </form>
+      </div>
+
       <p className="text-center text-sm text-gray-500 mt-6">
         Don&apos;t have an account?{" "}
-        <Link href="/register" className="text-blue-600 hover:underline">
+        <Link href={registerHref} className="text-blue-600 hover:underline">
           Sign up free
         </Link>
       </p>

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,49 +1,179 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+import { getProviders, signIn } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
+import { GoogleSignInButton } from "@/components/auth/GoogleSignInButton";
+import { PasswordRequirements } from "@/components/auth/PasswordRequirements";
+import { registerSchema } from "@/lib/auth-validation";
 
-export default function RegisterPage() {
+type RegisterFieldErrors = Partial<
+  Record<"name" | "email" | "password" | "confirmPassword" | "termsAccepted", string>
+>;
+
+function mapFieldErrors(fieldErrors?: Record<string, string[] | undefined>) {
+  return Object.fromEntries(
+    Object.entries(fieldErrors ?? {})
+      .map(([field, errors]) => [field, errors?.[0]])
+      .filter((entry): entry is [string, string] => Boolean(entry[1]))
+  ) as RegisterFieldErrors;
+}
+
+function Divider() {
+  return (
+    <div className="relative">
+      <div className="absolute inset-0 flex items-center">
+        <div className="w-full border-t border-gray-200" />
+      </div>
+      <div className="relative flex justify-center text-xs uppercase tracking-wide text-gray-400">
+        <span className="bg-white px-3">Or continue with email</span>
+      </div>
+    </div>
+  );
+}
+
+function RegisterForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectTo = searchParams.get("callbackUrl") ?? "/dashboard";
+  const loginHref =
+    redirectTo === "/dashboard"
+      ? "/login"
+      : `/login?callbackUrl=${encodeURIComponent(redirectTo)}`;
+
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [termsAccepted, setTermsAccepted] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
+  const [googleEnabled, setGoogleEnabled] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<RegisterFieldErrors>({});
+
+  useEffect(() => {
+    let active = true;
+
+    getProviders()
+      .then((providers) => {
+        if (active) {
+          setGoogleEnabled(Boolean(providers?.google));
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setGoogleEnabled(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  function clearFieldError(field: keyof RegisterFieldErrors) {
+    setFieldErrors((current) => {
+      if (!current[field]) return current;
+
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  }
+
+  async function handleGoogleSignIn() {
+    setError("");
+    setGoogleLoading(true);
+
+    try {
+      await signIn("google", { redirectTo });
+    } finally {
+      setGoogleLoading(false);
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
+
+    const payload = {
+      name,
+      email,
+      password,
+      confirmPassword,
+      termsAccepted,
+    };
+
+    const parsed = registerSchema.safeParse(payload);
+    if (!parsed.success) {
+      setFieldErrors(mapFieldErrors(parsed.error.flatten().fieldErrors));
+      return;
+    }
+
+    setFieldErrors({});
     setLoading(true);
-    const res = await fetch("/api/auth/register", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, email, password, termsAccepted }),
-    });
-    const data = await res.json();
-    setLoading(false);
-    if (!res.ok) {
-      setError(data.error || "Registration failed.");
-    } else {
-      router.push("/login?registered=1");
+
+    try {
+      const res = await fetch("/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json().catch(() => null);
+
+      if (!res.ok) {
+        setFieldErrors(mapFieldErrors(data?.fieldErrors));
+        setError(data?.error || "Registration failed.");
+        return;
+      }
+
+      const result = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+        redirectTo,
+      });
+
+      if (result?.error) {
+        router.push(
+          redirectTo === "/dashboard"
+            ? "/login?registered=1"
+            : `/login?registered=1&callbackUrl=${encodeURIComponent(redirectTo)}`
+        );
+        return;
+      }
+
+      router.push(result?.url ?? redirectTo);
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
     }
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
-      <div className="w-full max-w-md bg-white rounded-2xl shadow-sm border border-gray-200 p-6 sm:p-8">
-        <div className="mb-8 text-center">
-          <h1 className="text-2xl font-bold text-gray-900">InventoryAlert</h1>
-          <p className="text-gray-500 mt-1 text-sm">Create a free account</p>
-        </div>
+    <>
+      <div className="space-y-4">
+        {googleEnabled && (
+          <>
+            <GoogleSignInButton
+              label={googleLoading ? "Connecting to Google..." : "Continue with Google"}
+              disabled={loading || googleLoading}
+              onClick={handleGoogleSignIn}
+            />
+            <Divider />
+          </>
+        )}
+
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (
             <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
               {error}
             </div>
           )}
+
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
               Name
@@ -51,10 +181,17 @@ export default function RegisterPage() {
             <input
               type="text"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => {
+                setName(e.target.value);
+                clearFieldError("name");
+              }}
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
+            {fieldErrors.name && (
+              <p className="mt-1 text-xs text-red-600">{fieldErrors.name}</p>
+            )}
           </div>
+
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
               Email
@@ -62,11 +199,18 @@ export default function RegisterPage() {
             <input
               type="email"
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                clearFieldError("email");
+              }}
               required
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
+            {fieldErrors.email && (
+              <p className="mt-1 text-xs text-red-600">{fieldErrors.email}</p>
+            )}
           </div>
+
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
               Password
@@ -74,19 +218,50 @@ export default function RegisterPage() {
             <input
               type="password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                clearFieldError("password");
+              }}
               required
-              minLength={8}
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
-            <p className="text-xs text-gray-400 mt-1">Minimum 8 characters</p>
+            {fieldErrors.password && (
+              <p className="mt-1 text-xs text-red-600">{fieldErrors.password}</p>
+            )}
           </div>
+
+          <PasswordRequirements password={password} />
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Confirm password
+            </label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => {
+                setConfirmPassword(e.target.value);
+                clearFieldError("confirmPassword");
+              }}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {fieldErrors.confirmPassword && (
+              <p className="mt-1 text-xs text-red-600">
+                {fieldErrors.confirmPassword}
+              </p>
+            )}
+          </div>
+
           <div className="flex items-start gap-3">
             <input
               id="terms"
               type="checkbox"
               checked={termsAccepted}
-              onChange={(e) => setTermsAccepted(e.target.checked)}
+              onChange={(e) => {
+                setTermsAccepted(e.target.checked);
+                clearFieldError("termsAccepted");
+              }}
               className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer rounded border-gray-300 accent-blue-600"
             />
             <label htmlFor="terms" className="text-sm text-gray-600 leading-5">
@@ -100,23 +275,44 @@ export default function RegisterPage() {
               </Link>
             </label>
           </div>
+          {fieldErrors.termsAccepted && (
+            <p className="text-xs text-red-600">{fieldErrors.termsAccepted}</p>
+          )}
+
           <button
             type="submit"
-            disabled={loading || !termsAccepted}
+            disabled={loading || googleLoading}
             className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
           >
-            {loading ? "Creating account…" : "Create account"}
+            {loading ? "Creating account..." : "Create account"}
           </button>
         </form>
-        <p className="text-center text-sm text-gray-500 mt-6">
-          Already have an account?{" "}
-          <Link href="/login" className="text-blue-600 hover:underline">
-            Sign in
-          </Link>
-        </p>
-        <p className="text-center text-xs text-gray-400 mt-3">
-          Free plan includes up to 5 inventory items.
-        </p>
+      </div>
+
+      <p className="text-center text-sm text-gray-500 mt-6">
+        Already have an account?{" "}
+        <Link href={loginHref} className="text-blue-600 hover:underline">
+          Sign in
+        </Link>
+      </p>
+      <p className="text-center text-xs text-gray-400 mt-3">
+        Free plan includes up to 5 inventory items.
+      </p>
+    </>
+  );
+}
+
+export default function RegisterPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md bg-white rounded-2xl shadow-sm border border-gray-200 p-6 sm:p-8">
+        <div className="mb-8 text-center">
+          <h1 className="text-2xl font-bold text-gray-900">InventoryAlert</h1>
+          <p className="text-gray-500 mt-1 text-sm">Create a free account</p>
+        </div>
+        <Suspense>
+          <RegisterForm />
+        </Suspense>
       </div>
     </div>
   );

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,8 +1,20 @@
 "use client";
 
-import { useState, Suspense } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
+import { PasswordRequirements } from "@/components/auth/PasswordRequirements";
+import { resetPasswordSchema } from "@/lib/auth-validation";
+
+type ResetFieldErrors = Partial<Record<"password" | "confirmPassword", string>>;
+
+function mapFieldErrors(fieldErrors?: Record<string, string[] | undefined>) {
+  return Object.fromEntries(
+    Object.entries(fieldErrors ?? {})
+      .map(([field, errors]) => [field, errors?.[0]])
+      .filter((entry): entry is [string, string] => Boolean(entry[1]))
+  ) as ResetFieldErrors;
+}
 
 function ResetPasswordForm() {
   const router = useRouter();
@@ -10,27 +22,46 @@ function ResetPasswordForm() {
   const token = searchParams.get("token") ?? "";
 
   const [password, setPassword] = useState("");
-  const [confirm, setConfirm] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<ResetFieldErrors>({});
+
+  function clearFieldError(field: keyof ResetFieldErrors) {
+    setFieldErrors((current) => {
+      if (!current[field]) return current;
+
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
-    if (password !== confirm) {
-      setError("Passwords do not match.");
+
+    const payload = { token, password, confirmPassword };
+    const parsed = resetPasswordSchema.safeParse(payload);
+    if (!parsed.success) {
+      setFieldErrors(mapFieldErrors(parsed.error.flatten().fieldErrors));
       return;
     }
+
+    setFieldErrors({});
     setLoading(true);
+
     try {
       const res = await fetch("/api/auth/reset-password", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token, password }),
+        body: JSON.stringify(payload),
       });
-      const data = await res.json();
+      const data = await res.json().catch(() => null);
+
       if (!res.ok) {
-        setError(data.error ?? "Something went wrong.");
+        setFieldErrors(mapFieldErrors(data?.fieldErrors));
+        setError(data?.error ?? "Something went wrong.");
       } else {
         router.push("/login?reset=1");
       }
@@ -68,32 +99,51 @@ function ResetPasswordForm() {
         <input
           type="password"
           value={password}
-          onChange={(e) => setPassword(e.target.value)}
+          onChange={(e) => {
+            setPassword(e.target.value);
+            clearFieldError("password");
+          }}
           required
-          minLength={8}
           className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
+        {fieldErrors.password && (
+          <p className="mt-1 text-xs text-red-600">{fieldErrors.password}</p>
+        )}
       </div>
+
+      <PasswordRequirements password={password} />
+
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-1">
           Confirm new password
         </label>
         <input
           type="password"
-          value={confirm}
-          onChange={(e) => setConfirm(e.target.value)}
+          value={confirmPassword}
+          onChange={(e) => {
+            setConfirmPassword(e.target.value);
+            clearFieldError("confirmPassword");
+          }}
           required
-          minLength={8}
           className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
+        {fieldErrors.confirmPassword && (
+          <p className="mt-1 text-xs text-red-600">
+            {fieldErrors.confirmPassword}
+          </p>
+        )}
       </div>
+
       <button
         type="submit"
         disabled={loading}
         className="w-full bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
       >
-        {loading ? "Saving…" : "Set new password"}
+        {loading ? "Saving..." : "Set new password"}
       </button>
+      <p className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-700">
+        You can use this same flow to add a password to an account that started with Google sign-in.
+      </p>
       <p className="text-center text-sm text-gray-500">
         <Link href="/login" className="text-blue-600 hover:underline">
           Back to sign in

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { sendPasswordResetEmail } from "@/lib/resend";
+import { normalizeEmail } from "@/lib/auth-validation";
 
 const schema = z.object({
   email: z.string().email(),
@@ -19,8 +20,15 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const { email } = parsed.data;
-    const user = await prisma.user.findUnique({ where: { email } });
+    const normalizedEmail = normalizeEmail(parsed.data.email);
+    const user = await prisma.user.findFirst({
+      where: {
+        email: {
+          equals: normalizedEmail,
+          mode: "insensitive",
+        },
+      },
+    });
 
     if (user) {
       const rawToken = crypto.randomBytes(32).toString("hex");
@@ -34,10 +42,10 @@ export async function POST(req: NextRequest) {
 
       const resetUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/reset-password?token=${rawToken}`;
       try {
-        await sendPasswordResetEmail(email, resetUrl);
+        await sendPasswordResetEmail(user.email, resetUrl);
       } catch {
         // Log but don't expose email delivery failures
-        console.error("Failed to send password reset email to", email);
+        console.error("Failed to send password reset email to", user.email);
       }
     }
 

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,44 +1,73 @@
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
-import { z } from "zod";
+import { AuthProvider } from "@prisma/client";
+import { normalizeEmail, registerSchema } from "@/lib/auth-validation";
+import { ensureCredentialsIdentity } from "@/lib/auth-identities";
 
 const TERMS_VERSION = "2026-04-18";
-
-const schema = z.object({
-  name: z.string().max(100).optional(),
-  email: z.string().email(),
-  password: z.string().min(8),
-  termsAccepted: z.literal(true, { message: "You must accept the Terms of Service to register." }),
-});
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const parsed = schema.safeParse(body);
+    const parsed = registerSchema.safeParse(body);
     if (!parsed.success) {
+      const fieldErrors = parsed.error.flatten().fieldErrors;
       return NextResponse.json(
-        { error: parsed.error.issues[0].message },
+        {
+          error: parsed.error.issues[0].message,
+          fieldErrors,
+        },
         { status: 400 }
       );
     }
 
     const { name, email, password } = parsed.data;
+    const normalizedEmail = normalizeEmail(email);
 
-    const existing = await prisma.user.findUnique({ where: { email } });
+    const existing = await prisma.user.findFirst({
+      where: {
+        email: {
+          equals: normalizedEmail,
+          mode: "insensitive",
+        },
+      },
+      include: {
+        authIdentities: {
+          select: { provider: true },
+        },
+      },
+    });
     if (existing) {
+      const usesGoogleOnly =
+        !existing.hashedPassword &&
+        existing.authIdentities.some(
+          (identity) => identity.provider === AuthProvider.GOOGLE
+        );
+
       return NextResponse.json(
-        { error: "An account with this email already exists." },
+        {
+          error: usesGoogleOnly
+            ? "An account with this email already uses Google sign-in. Continue with Google or use Forgot password to create a password."
+            : "An account with this email already exists. Sign in instead.",
+        },
         { status: 409 }
       );
     }
 
     const hashedPassword = await bcrypt.hash(password, 12);
-    await prisma.user.create({
-      data: { email, hashedPassword, name, termsAcceptedAt: new Date(), termsVersion: TERMS_VERSION },
+    const user = await prisma.user.create({
+      data: {
+        email: normalizedEmail,
+        hashedPassword,
+        name,
+        termsAcceptedAt: new Date(),
+        termsVersion: TERMS_VERSION,
+      },
     });
+    await ensureCredentialsIdentity(user.id);
 
-    return NextResponse.json({ ok: true }, { status: 201 });
+    return NextResponse.json({ ok: true, email: normalizedEmail }, { status: 201 });
   } catch {
     return NextResponse.json({ error: "Server error" }, { status: 500 });
   }

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,21 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 import bcrypt from "bcryptjs";
-import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-
-const schema = z.object({
-  token: z.string().min(1),
-  password: z.string().min(8),
-});
+import { ensureCredentialsIdentity } from "@/lib/auth-identities";
+import { resetPasswordSchema } from "@/lib/auth-validation";
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const parsed = schema.safeParse(body);
+    const parsed = resetPasswordSchema.safeParse(body);
     if (!parsed.success) {
+      const fieldErrors = parsed.error.flatten().fieldErrors;
       return NextResponse.json(
-        { error: parsed.error.issues[0].message },
+        {
+          error: parsed.error.issues[0].message,
+          fieldErrors,
+        },
         { status: 400 }
       );
     }
@@ -46,6 +46,7 @@ export async function POST(req: NextRequest) {
         passwordResetExpiry: null,
       },
     });
+    await ensureCredentialsIdentity(user.id);
 
     return NextResponse.json({ ok: true });
   } catch {

--- a/components/auth/GoogleSignInButton.tsx
+++ b/components/auth/GoogleSignInButton.tsx
@@ -1,0 +1,44 @@
+type GoogleSignInButtonProps = {
+  disabled?: boolean;
+  label: string;
+  onClick: () => void | Promise<void>;
+};
+
+export function GoogleSignInButton({
+  disabled = false,
+  label,
+  onClick,
+}: GoogleSignInButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => void onClick()}
+      disabled={disabled}
+      className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        className="h-5 w-5"
+      >
+        <path
+          fill="#4285F4"
+          d="M23.49 12.27c0-.79-.07-1.55-.2-2.27H12v4.3h6.45a5.51 5.51 0 0 1-2.39 3.61v2.99h3.87c2.26-2.08 3.56-5.14 3.56-8.63Z"
+        />
+        <path
+          fill="#34A853"
+          d="M12 24c3.24 0 5.95-1.07 7.94-2.9l-3.87-2.99c-1.07.72-2.45 1.14-4.07 1.14-3.13 0-5.78-2.11-6.73-4.95H1.27v3.08A12 12 0 0 0 12 24Z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M5.27 14.3A7.2 7.2 0 0 1 4.9 12c0-.8.14-1.58.37-2.3V6.62H1.27A12 12 0 0 0 0 12c0 1.94.46 3.78 1.27 5.38l4-3.08Z"
+        />
+        <path
+          fill="#EA4335"
+          d="M12 4.77c1.76 0 3.34.61 4.59 1.82l3.44-3.44C17.94 1.18 15.24 0 12 0A12 12 0 0 0 1.27 6.62l4 3.08c.95-2.84 3.6-4.93 6.73-4.93Z"
+        />
+      </svg>
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/components/auth/PasswordRequirements.tsx
+++ b/components/auth/PasswordRequirements.tsx
@@ -1,0 +1,31 @@
+import { getPasswordRequirementStates } from "@/lib/auth-validation";
+
+type PasswordRequirementsProps = {
+  password: string;
+};
+
+export function PasswordRequirements({
+  password,
+}: PasswordRequirementsProps) {
+  const requirements = getPasswordRequirementStates(password);
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-3">
+      <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+        Password requirements
+      </p>
+      <ul className="mt-2 space-y-1">
+        {requirements.map((requirement) => (
+          <li
+            key={requirement.id}
+            className={`text-xs ${
+              requirement.met ? "text-green-700" : "text-gray-500"
+            }`}
+          >
+            {requirement.met ? "✓" : "○"} {requirement.label}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/lib/auth-errors.ts
+++ b/lib/auth-errors.ts
@@ -1,0 +1,7 @@
+import { CredentialsSignin } from "next-auth";
+
+export const GOOGLE_SIGNIN_REQUIRED_CODE = "google_signin_required";
+
+export class GoogleSignInRequiredError extends CredentialsSignin {
+  code = GOOGLE_SIGNIN_REQUIRED_CODE;
+}

--- a/lib/auth-identities.ts
+++ b/lib/auth-identities.ts
@@ -1,0 +1,35 @@
+import { AuthProvider, type Tier } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+type SessionUserShape = {
+  id: string;
+  email: string;
+  name?: string | null;
+  tier: Tier;
+};
+
+export async function ensureCredentialsIdentity(userId: string) {
+  await prisma.authIdentity.upsert({
+    where: {
+      provider_providerAccountId: {
+        provider: AuthProvider.CREDENTIALS,
+        providerAccountId: userId,
+      },
+    },
+    update: { userId },
+    create: {
+      userId,
+      provider: AuthProvider.CREDENTIALS,
+      providerAccountId: userId,
+    },
+  });
+}
+
+export function toSessionUser(user: SessionUserShape) {
+  return {
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    tier: user.tier,
+  };
+}

--- a/lib/auth-validation.ts
+++ b/lib/auth-validation.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+
+export const PASSWORD_MIN_LENGTH = 8;
+
+const LOWERCASE_REGEX = /[a-z]/;
+const UPPERCASE_REGEX = /[A-Z]/;
+const NUMBER_REGEX = /[0-9]/;
+const SPECIAL_CHARACTER_REGEX = /[^A-Za-z0-9]/;
+
+export function normalizeEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+function normalizeOptionalName(value: unknown) {
+  if (typeof value !== "string") return undefined;
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export const passwordSchema = z
+  .string()
+  .min(
+    PASSWORD_MIN_LENGTH,
+    `Password must be at least ${PASSWORD_MIN_LENGTH} characters long.`
+  )
+  .regex(LOWERCASE_REGEX, "Password must include at least one lowercase letter.")
+  .regex(UPPERCASE_REGEX, "Password must include at least one uppercase letter.")
+  .regex(NUMBER_REGEX, "Password must include at least one number.")
+  .regex(
+    SPECIAL_CHARACTER_REGEX,
+    "Password must include at least one special character."
+  );
+
+export const registerSchema = z
+  .object({
+    name: z.preprocess(
+      normalizeOptionalName,
+      z.string().max(100, "Name must be 100 characters or fewer.").optional()
+    ),
+    email: z
+      .string()
+      .trim()
+      .min(1, "Email is required.")
+      .email("Enter a valid email address."),
+    password: passwordSchema,
+    confirmPassword: z.string().min(1, "Please confirm your password."),
+    termsAccepted: z
+      .boolean()
+      .refine((value) => value, {
+        message: "You must accept the Terms of Service to create an account.",
+      }),
+  })
+  .superRefine(({ password, confirmPassword }, ctx) => {
+    if (password !== confirmPassword) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["confirmPassword"],
+        message: "Passwords do not match.",
+      });
+    }
+  });
+
+export const resetPasswordSchema = z
+  .object({
+    token: z.string().min(1, "Invalid reset link."),
+    password: passwordSchema,
+    confirmPassword: z.string().min(1, "Please confirm your password."),
+  })
+  .superRefine(({ password, confirmPassword }, ctx) => {
+    if (password !== confirmPassword) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["confirmPassword"],
+        message: "Passwords do not match.",
+      });
+    }
+  });
+
+export type RegisterInput = z.infer<typeof registerSchema>;
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;
+
+export function getPasswordRequirementStates(password: string) {
+  return [
+    {
+      id: "length",
+      label: `At least ${PASSWORD_MIN_LENGTH} characters`,
+      met: password.length >= PASSWORD_MIN_LENGTH,
+    },
+    {
+      id: "lowercase",
+      label: "At least one lowercase letter",
+      met: LOWERCASE_REGEX.test(password),
+    },
+    {
+      id: "uppercase",
+      label: "At least one uppercase letter",
+      met: UPPERCASE_REGEX.test(password),
+    },
+    {
+      id: "number",
+      label: "At least one number",
+      met: NUMBER_REGEX.test(password),
+    },
+    {
+      id: "special",
+      label: "At least one special character",
+      met: SPECIAL_CHARACTER_REGEX.test(password),
+    },
+  ];
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,8 +1,13 @@
 import NextAuth from "next-auth";
+import { AuthProvider, type Tier } from "@prisma/client";
+import { CredentialsSignin } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
+import Google, { type GoogleProfile } from "next-auth/providers/google";
 import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
-import type { Tier } from "@prisma/client";
+import { GoogleSignInRequiredError } from "@/lib/auth-errors";
+import { ensureCredentialsIdentity, toSessionUser } from "@/lib/auth-identities";
+import { normalizeEmail } from "@/lib/auth-validation";
 
 declare module "next-auth" {
   interface Session {
@@ -25,6 +30,19 @@ declare module "next-auth" {
   }
 }
 
+function getGoogleProvider() {
+  if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
+    return null;
+  }
+
+  return Google({
+    clientId: process.env.GOOGLE_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+  });
+}
+
+const googleProvider = getGoogleProvider();
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: [
     Credentials({
@@ -35,11 +53,32 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       async authorize(credentials) {
         if (!credentials?.email || !credentials?.password) return null;
 
-        const user = await prisma.user.findUnique({
-          where: { email: credentials.email as string },
+        const email = normalizeEmail(credentials.email as string);
+        const user = await prisma.user.findFirst({
+          where: {
+            email: {
+              equals: email,
+              mode: "insensitive",
+            },
+          },
         });
 
         if (!user) return null;
+        if (!user.hashedPassword) {
+          const hasGoogleIdentity = await prisma.authIdentity.findFirst({
+            where: {
+              userId: user.id,
+              provider: AuthProvider.GOOGLE,
+            },
+            select: { id: true },
+          });
+
+          if (hasGoogleIdentity) {
+            throw new GoogleSignInRequiredError();
+          }
+
+          throw new CredentialsSignin();
+        }
 
         const valid = await bcrypt.compare(
           credentials.password as string,
@@ -47,26 +86,113 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         );
         if (!valid) return null;
 
-        return {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          tier: user.tier,
-        };
+        await ensureCredentialsIdentity(user.id);
+
+        return toSessionUser(user);
       },
     }),
+    ...(googleProvider ? [googleProvider] : []),
   ],
   callbacks: {
+    async signIn({ user, account, profile }) {
+      if (account?.provider !== "google") {
+        return true;
+      }
+
+      const googleProfile = profile as GoogleProfile | undefined;
+      if (
+        !googleProfile?.email ||
+        !googleProfile.sub ||
+        !googleProfile.email_verified
+      ) {
+        return false;
+      }
+
+      const normalizedEmail = normalizeEmail(googleProfile.email);
+      const providerAccountId = googleProfile.sub;
+      const now = new Date();
+
+      const existingIdentity = await prisma.authIdentity.findUnique({
+        where: {
+          provider_providerAccountId: {
+            provider: AuthProvider.GOOGLE,
+            providerAccountId,
+          },
+        },
+        include: {
+          user: true,
+        },
+      });
+
+      let linkedUser = existingIdentity?.user;
+
+      if (!linkedUser) {
+        const matchingUser = await prisma.user.findFirst({
+          where: {
+            email: {
+              equals: normalizedEmail,
+              mode: "insensitive",
+            },
+          },
+        });
+
+        if (matchingUser) {
+          linkedUser = await prisma.user.update({
+            where: { id: matchingUser.id },
+            data: {
+              email: normalizedEmail,
+              emailVerifiedAt: matchingUser.emailVerifiedAt ?? now,
+              name: matchingUser.name ?? user.name ?? googleProfile.name,
+            },
+          });
+        } else {
+          linkedUser = await prisma.user.create({
+            data: {
+              email: normalizedEmail,
+              emailVerifiedAt: now,
+              name: user.name ?? googleProfile.name,
+            },
+          });
+        }
+
+        await prisma.authIdentity.create({
+          data: {
+            userId: linkedUser.id,
+            provider: AuthProvider.GOOGLE,
+            providerAccountId,
+          },
+        });
+      } else if (!linkedUser.emailVerifiedAt || !linkedUser.name) {
+        linkedUser = await prisma.user.update({
+          where: { id: linkedUser.id },
+          data: {
+            emailVerifiedAt: linkedUser.emailVerifiedAt ?? now,
+            name: linkedUser.name ?? user.name ?? googleProfile.name,
+          },
+        });
+      }
+
+      user.id = linkedUser.id;
+      user.email = linkedUser.email;
+      user.name = linkedUser.name;
+      user.tier = linkedUser.tier;
+
+      return true;
+    },
     async jwt({ token, user }) {
       if (user) {
         token["id"] = user.id;
         token["tier"] = user.tier;
+        token.email = user.email;
+        token.name = user.name;
       }
       return token;
     },
     async session({ session, token }) {
       session.user.id = token["id"] as string;
       session.user.tier = token["tier"] as Tier;
+      session.user.email = token.email as string;
+      session.user.name = token.name as string | null | undefined;
       return session;
     },
   },

--- a/prisma/migrations/20260419193000_add_auth_identities/migration.sql
+++ b/prisma/migrations/20260419193000_add_auth_identities/migration.sql
@@ -1,0 +1,43 @@
+-- CreateEnum
+CREATE TYPE "AuthProvider" AS ENUM ('CREDENTIALS', 'GOOGLE');
+
+-- AlterTable
+ALTER TABLE "User"
+ALTER COLUMN "hashedPassword" DROP NOT NULL,
+ADD COLUMN "emailVerifiedAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "AuthIdentity" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "provider" "AuthProvider" NOT NULL,
+    "providerAccountId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AuthIdentity_pkey" PRIMARY KEY ("id")
+);
+
+-- Backfill credentials identities for existing password-based users
+INSERT INTO "AuthIdentity" ("id", "userId", "provider", "providerAccountId", "createdAt", "updatedAt")
+SELECT
+    'credentials_' || "id",
+    "id",
+    'CREDENTIALS',
+    "id",
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+FROM "User"
+WHERE "hashedPassword" IS NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuthIdentity_provider_providerAccountId_key" ON "AuthIdentity"("provider", "providerAccountId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuthIdentity_userId_provider_key" ON "AuthIdentity"("userId", "provider");
+
+-- CreateIndex
+CREATE INDEX "AuthIdentity_userId_idx" ON "AuthIdentity"("userId");
+
+-- AddForeignKey
+ALTER TABLE "AuthIdentity" ADD CONSTRAINT "AuthIdentity_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,15 +29,21 @@ enum RecipientKind {
   INLINE_EMAIL
 }
 
+enum AuthProvider {
+  CREDENTIALS
+  GOOGLE
+}
+
 model User {
   id                     String          @id @default(cuid())
   email                  String          @unique
-  hashedPassword         String
+  hashedPassword         String?
   name                   String?
   tier                   Tier            @default(FREE)
   stripeCustomerId       String?         @unique
   stripeSubscriptionId   String?         @unique
   stripeCurrentPeriodEnd DateTime?
+  emailVerifiedAt        DateTime?
   passwordResetToken     String?
   passwordResetExpiry    DateTime?
   termsAcceptedAt        DateTime?
@@ -48,8 +54,23 @@ model User {
   items                  InventoryItem[]
   contacts               AlertContact[]
   pushSubscriptions      PushSubscription[]
+  authIdentities         AuthIdentity[]
 }
 
+model AuthIdentity {
+  id                String       @id @default(cuid())
+  userId            String
+  provider          AuthProvider
+  providerAccountId String
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
+
+  user              User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+  @@unique([userId, provider])
+  @@index([userId])
+}
 
 model PushSubscription {
   id        String   @id @default(cuid())


### PR DESCRIPTION
## Summary
Add Google sign-in as the first social auth provider, refactor auth storage so additional providers can be added later, and harden the credentials signup/reset flows with stronger validation and clearer UX.

## What Changed
- Added linked auth identities in Prisma so one user can sign in with multiple methods.
- Made `User.hashedPassword` optional and added `emailVerifiedAt`.
- Added Google auth to the NextAuth config with same-email account linking.
- Preserved one-email-per-user behavior across Google and credentials auth.
- Added Google-first account handling so users can set a password later through the existing reset flow.
- Upgraded register/reset validation to require:
  - minimum 8 characters
  - lowercase letter
  - uppercase letter
  - number
  - special character
  - password confirmation
- Added Google CTAs plus improved field-level validation on login/register/reset pages.
- Added Google env vars and callback documentation to `.env.example`.

## Verification
- `prisma generate`
- `tsc --noEmit`
- `npm run build`

## Notes
- The migration to apply is `20260419193000_add_auth_identities`.
- Local `.claude` files were intentionally excluded from the commit.