### PR TITLE
Escape user values in alert email HTML and clean up replaced blob images

### DIFF
--- a/app/api/items/[itemId]/route.ts
+++ b/app/api/items/[itemId]/route.ts
@@ -166,6 +166,20 @@ export async function PATCH(req: NextRequest, { params }: Params) {
       return updatedItem;
     });
 
+    // Remove the previous blob when the image was replaced or cleared, so
+    // storage doesn't accumulate unreferenced (but still public) images.
+    if (
+      rest.imageUrl !== undefined &&
+      existing.imageUrl &&
+      (rest.imageUrl || null) !== existing.imageUrl
+    ) {
+      try {
+        await del(existing.imageUrl);
+      } catch (blobErr) {
+        console.error("Failed to delete replaced blob image:", blobErr);
+      }
+    }
+
     return NextResponse.json(updated);
   } catch (err) {
     if (err instanceof RecipientConfigError) {

--- a/lib/resend.ts
+++ b/lib/resend.ts
@@ -11,6 +11,17 @@ function getResendClient(): Resend {
   return resendClient;
 }
 
+// User-controlled values (e.g. item names) must be escaped before being
+// interpolated into email HTML — recipients may not be the account owner.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 export async function sendPasswordResetEmail(to: string, resetUrl: string): Promise<void> {
   await getResendClient().emails.send({
     from: process.env.RESEND_FROM_EMAIL!,
@@ -32,14 +43,16 @@ export async function sendPasswordResetEmail(to: string, resetUrl: string): Prom
 
 export async function sendAlertEmail(to: string | string[], itemName: string): Promise<void> {
   const now = new Date().toLocaleString("en-US", { timeZone: "UTC" });
+  const safeItemName = escapeHtml(itemName);
   await getResendClient().emails.send({
     from: process.env.RESEND_FROM_EMAIL!,
     to,
+    // Subjects are rendered as plain text by mail clients — no escaping needed there.
     subject: `Low Stock Alert: ${itemName}`,
     html: `
       <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;">
         <h2 style="color: #dc2626;">Low Stock Alert</h2>
-        <p>A low stock alert was triggered for <strong>${itemName}</strong>.</p>
+        <p>A low stock alert was triggered for <strong>${safeItemName}</strong>.</p>
         <p>A QR code was scanned at <strong>${now} UTC</strong>, indicating that this item may need restocking.</p>
         <p>Please log in to your InventoryAlert dashboard to review and action the stocking request.</p>
         <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;" />


### PR DESCRIPTION
Closes #66, closes #69 — from the production-readiness backlog (#70).

## Email HTML escaping (#66)
`sendAlertEmail` interpolated the item name directly into the email HTML body. Item names are user-controlled (up to 100 chars), and alert recipients may be third parties — an item named `<a href="https://evil.example">…</a>` injected live HTML into a legitimate transactional email from the app's domain. The name is now passed through an `escapeHtml` helper before interpolation.

The subject line is intentionally **not** escaped: mail clients render subjects as plain text, so escaping there would display literal entities (`&amp;` etc.). The password-reset template contains no user-controlled values (the reset URL is server-constructed).

## Replaced-image blob cleanup (#69)
Item PATCH previously overwrote `imageUrl` and left the old blob in storage — unreferenced but still publicly accessible, accumulating cost forever. After a successful update, if the image was replaced or cleared, the old blob is deleted (guarded — a blob-store failure logs and does not fail the item update, matching the DELETE handler's policy).

## Verification
- `npm run lint` — 0 errors; `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tTuca5mDZ8i5QMr6LD4Xh

---
_Generated by [Claude Code](https://claude.ai/code/session_016tTuca5mDZ8i5QMr6LD4Xh)_