### PR TITLE
Add security headers to all responses

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,35 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  {
+    // Nothing in the app (dashboard, auth, or the public scan page) should
+    // ever be framed — blocks clickjacking. frame-ancestors covers modern
+    // browsers; X-Frame-Options covers legacy ones.
+    key: "Content-Security-Policy",
+    value: "frame-ancestors 'none'",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+];
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
@@ -8,6 +38,14 @@ const nextConfig: NextConfig = {
         hostname: "*.public.blob.vercel-storage.com",
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
Closes #60 — from the production-readiness backlog (#70).

Adds a `headers()` block to `next.config.ts` applying to every route (dashboard, auth, and the public scan page):

| Header | Value | Purpose |
|---|---|---|
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | Force HTTPS for 2 years |
| `Content-Security-Policy` | `frame-ancestors 'none'` | Clickjacking (modern browsers) |
| `X-Frame-Options` | `DENY` | Clickjacking (legacy browsers) |
| `X-Content-Type-Options` | `nosniff` | MIME sniffing |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Referrer leakage |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disable unused sensors |

A full `script-src` CSP is intentionally deferred — it requires nonce propagation for Next.js inline scripts and should be rolled out report-only first; noted on #60 before closing.

## Verification
Ran the production build locally and confirmed with `curl -I`:
- All six headers present on `/login`
- `manifest.json` and `sw.js` still return 200 (PWA install + push unaffected)
- `npm run lint` 0 errors, `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tTuca5mDZ8i5QMr6LD4Xh

---
_Generated by [Claude Code](https://claude.ai/code/session_016tTuca5mDZ8i5QMr6LD4Xh)_