### PR TITLE
Add DB-backed rate limiting to public and auth endpoints

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -111,6 +111,7 @@
 │   ├── stripe.ts                 # Stripe client
 │   ├── resend.ts                 # Resend email client + sendAlertEmail() + sendPasswordResetEmail()
 │   ├── push.ts                   # sendStockingPushNotification() via web-push (VAPID)
+│   ├── rate-limit.ts             # DB-backed fixed-window rate limiter (RATE_LIMITS, checkRateLimit)
 │   ├── tier.ts                   # TIER_LIMITS, canCreateItem()
 │   ├── label.ts                  # LABEL_SIZES, LABEL_SIZE_CONFIG, TextElement, getDefaultTextElements()
 │   └── validations/

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -4,6 +4,12 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { sendPasswordResetEmail } from "@/lib/resend";
 import { normalizeEmail } from "@/lib/auth-validation";
+import {
+  RATE_LIMITS,
+  checkRateLimit,
+  getClientIp,
+  rateLimitResponse,
+} from "@/lib/rate-limit";
 
 const schema = z.object({
   email: z.string().email(),
@@ -11,6 +17,17 @@ const schema = z.object({
 
 export async function POST(req: NextRequest) {
   try {
+    const ipLimit = await checkRateLimit(
+      `forgot-password:ip:${getClientIp(req)}`,
+      RATE_LIMITS.forgotPasswordPerIp
+    );
+    if (!ipLimit.allowed) {
+      return rateLimitResponse(
+        ipLimit.retryAfterSeconds,
+        "Too many password reset requests. Please try again later."
+      );
+    }
+
     const body = await req.json();
     const parsed = schema.safeParse(body);
     if (!parsed.success) {
@@ -21,6 +38,18 @@ export async function POST(req: NextRequest) {
     }
 
     const normalizedEmail = normalizeEmail(parsed.data.email);
+
+    // Also cap per target address across all IPs so a distributed attacker
+    // can't bombard one inbox with reset emails.
+    const emailLimit = await checkRateLimit(
+      `forgot-password:email:${normalizedEmail}`,
+      RATE_LIMITS.forgotPasswordPerEmail
+    );
+    if (!emailLimit.allowed) {
+      // Same body as the success path — a distinct error here would allow
+      // user enumeration; suppressing the send is enough.
+      return NextResponse.json({ ok: true });
+    }
     const user = await prisma.user.findFirst({
       where: {
         email: {

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -4,11 +4,28 @@ import { prisma } from "@/lib/prisma";
 import { AuthProvider } from "@prisma/client";
 import { normalizeEmail, registerSchema } from "@/lib/auth-validation";
 import { ensureCredentialsIdentity } from "@/lib/auth-identities";
+import {
+  RATE_LIMITS,
+  checkRateLimit,
+  getClientIp,
+  rateLimitResponse,
+} from "@/lib/rate-limit";
 
 const TERMS_VERSION = "2026-04-18";
 
 export async function POST(req: NextRequest) {
   try {
+    const limit = await checkRateLimit(
+      `register:ip:${getClientIp(req)}`,
+      RATE_LIMITS.registerPerIp
+    );
+    if (!limit.allowed) {
+      return rateLimitResponse(
+        limit.retryAfterSeconds,
+        "Too many registration attempts. Please try again later."
+      );
+    }
+
     const body = await req.json();
     const parsed = registerSchema.safeParse(body);
     if (!parsed.success) {

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -4,9 +4,27 @@ import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
 import { ensureCredentialsIdentity } from "@/lib/auth-identities";
 import { resetPasswordSchema } from "@/lib/auth-validation";
+import {
+  RATE_LIMITS,
+  checkRateLimit,
+  getClientIp,
+  rateLimitResponse,
+} from "@/lib/rate-limit";
 
 export async function POST(req: NextRequest) {
   try {
+    // Caps brute-force guessing of reset tokens.
+    const limit = await checkRateLimit(
+      `reset-password:ip:${getClientIp(req)}`,
+      RATE_LIMITS.resetPasswordPerIp
+    );
+    if (!limit.allowed) {
+      return rateLimitResponse(
+        limit.retryAfterSeconds,
+        "Too many attempts. Please try again later."
+      );
+    }
+
     const body = await req.json();
     const parsed = resetPasswordSchema.safeParse(body);
     if (!parsed.success) {

--- a/app/api/scan/[qrCodeId]/route.ts
+++ b/app/api/scan/[qrCodeId]/route.ts
@@ -3,6 +3,12 @@ import { prisma } from "@/lib/prisma";
 import { sendAlertEmail } from "@/lib/resend";
 import { sendStockingPushNotification } from "@/lib/push";
 import { getEffectiveRecipientEmails } from "@/lib/alert-recipients";
+import {
+  RATE_LIMITS,
+  checkRateLimit,
+  getClientIp,
+  rateLimitResponse,
+} from "@/lib/rate-limit";
 
 type Params = { params: Promise<{ qrCodeId: string }> };
 
@@ -25,8 +31,33 @@ async function notifyStockingRequestCreated(args: {
   }
 }
 
-export async function POST(_req: NextRequest, { params }: Params) {
+export async function POST(req: NextRequest, { params }: Params) {
   const { qrCodeId } = await params;
+
+  // Both checks run before the item lookup so a flood of scans (or probes
+  // against random QR ids) is cut off without touching the item table.
+  const ip = getClientIp(req);
+  const ipLimit = await checkRateLimit(
+    `scan:ip:${ip}:${qrCodeId}`,
+    RATE_LIMITS.scanPerIp
+  );
+  if (!ipLimit.allowed) {
+    return rateLimitResponse(
+      ipLimit.retryAfterSeconds,
+      "Too many scans from this device. Please try again later."
+    );
+  }
+
+  const itemLimit = await checkRateLimit(
+    `scan:item:${qrCodeId}`,
+    RATE_LIMITS.scanPerItem
+  );
+  if (!itemLimit.allowed) {
+    return rateLimitResponse(
+      itemLimit.retryAfterSeconds,
+      "This item has been scanned too many times recently. Please try again later."
+    );
+  }
 
   const item = await prisma.inventoryItem.findUnique({
     where: { qrCodeId },

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { put } from "@vercel/blob";
+import { RATE_LIMITS, checkRateLimit, rateLimitResponse } from "@/lib/rate-limit";
 
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
 const MAX_SIZE = 2 * 1024 * 1024; // 2 MB
@@ -8,6 +9,17 @@ const MAX_SIZE = 2 * 1024 * 1024; // 2 MB
 export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const limit = await checkRateLimit(
+    `upload:user:${session.user.id}`,
+    RATE_LIMITS.uploadPerUser
+  );
+  if (!limit.allowed) {
+    return rateLimitResponse(
+      limit.retryAfterSeconds,
+      "Too many uploads. Please try again later."
+    );
+  }
 
   const formData = await req.formData();
   const file = formData.get("file") as File | null;

--- a/app/scan/[qrCodeId]/page.tsx
+++ b/app/scan/[qrCodeId]/page.tsx
@@ -15,11 +15,17 @@ export default async function ScanPage({ params }: Props) {
   let acknowledgementMessage = "";
   let emailFailed = false;
   let error = false;
+  let rateLimited = false;
 
   try {
     const res = await fetch(`${baseUrl}/api/scan/${qrCodeId}`, {
       method: "POST",
       cache: "no-store",
+      // This fetch runs on the server, so the API would otherwise see the
+      // server's own IP — forward the visitor's chain for rate limiting.
+      headers: {
+        "x-forwarded-for": headersList.get("x-forwarded-for") ?? "",
+      },
     });
     if (res.ok) {
       const data = await res.json();
@@ -27,11 +33,29 @@ export default async function ScanPage({ params }: Props) {
       alreadyNotified = data.alreadyNotified;
       acknowledgementMessage = data.acknowledgementMessage ?? "";
       emailFailed = data.emailFailed ?? false;
+    } else if (res.status === 429) {
+      rateLimited = true;
     } else {
       error = true;
     }
   } catch {
     error = true;
+  }
+
+  if (rateLimited) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-200 p-8 text-center">
+          <h1 className="text-lg font-bold text-gray-900 mb-2">
+            Scanned too many times
+          </h1>
+          <p className="text-sm text-gray-500">
+            This item has been scanned many times recently, so no new alert was
+            sent. If it still needs restocking, please notify staff directly.
+          </p>
+        </div>
+      </div>
+    );
   }
 
   if (error) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -8,6 +8,7 @@ import { prisma } from "@/lib/prisma";
 import { GoogleSignInRequiredError } from "@/lib/auth-errors";
 import { ensureCredentialsIdentity, toSessionUser } from "@/lib/auth-identities";
 import { normalizeEmail } from "@/lib/auth-validation";
+import { RATE_LIMITS, checkRateLimit, getClientIp } from "@/lib/rate-limit";
 
 declare module "next-auth" {
   interface Session {
@@ -50,10 +51,23 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         email: { label: "Email", type: "email" },
         password: { label: "Password", type: "password" },
       },
-      async authorize(credentials) {
+      async authorize(credentials, request) {
         if (!credentials?.email || !credentials?.password) return null;
 
         const email = normalizeEmail(credentials.email as string);
+
+        // Brute-force protection: failed and successful attempts both count,
+        // keyed per IP + target account. Limited attempts surface as a normal
+        // credential failure so attackers learn nothing from the response.
+        const limit = await checkRateLimit(
+          `login:${getClientIp(request)}:${email}`,
+          RATE_LIMITS.loginPerIpEmail
+        );
+        if (!limit.allowed) {
+          console.warn(`Login rate limit hit for ${email}`);
+          throw new CredentialsSignin();
+        }
+
         const user = await prisma.user.findFirst({
           where: {
             email: {

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,96 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * DB-backed fixed-window rate limiter. Counters live in Postgres
+ * (RateLimitWindow) so limits hold across serverless function instances —
+ * an in-memory limiter would reset on every cold start.
+ *
+ * Fails open: if the counter can't be read or written, the request is
+ * allowed and the error logged. Rate limiting must never take the
+ * product down with it.
+ */
+
+export const RATE_LIMITS = {
+  scanPerIp: { limit: 30, windowSeconds: 3600 },
+  scanPerItem: { limit: 120, windowSeconds: 3600 },
+  loginPerIpEmail: { limit: 5, windowSeconds: 900 },
+  registerPerIp: { limit: 10, windowSeconds: 3600 },
+  forgotPasswordPerIp: { limit: 5, windowSeconds: 900 },
+  forgotPasswordPerEmail: { limit: 5, windowSeconds: 3600 },
+  resetPasswordPerIp: { limit: 10, windowSeconds: 3600 },
+  uploadPerUser: { limit: 30, windowSeconds: 3600 },
+} as const;
+
+export type RateLimitResult = {
+  allowed: boolean;
+  retryAfterSeconds: number;
+};
+
+// ~1% of calls sweep windows old enough to be irrelevant to any active limit.
+const CLEANUP_PROBABILITY = 0.01;
+const CLEANUP_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export async function checkRateLimit(
+  key: string,
+  config: { limit: number; windowSeconds: number }
+): Promise<RateLimitResult> {
+  const windowMs = config.windowSeconds * 1000;
+  const windowStart = new Date(Math.floor(Date.now() / windowMs) * windowMs);
+
+  try {
+    const row = await prisma.rateLimitWindow.upsert({
+      where: { key_windowStart: { key, windowStart } },
+      create: { key, windowStart },
+      update: { count: { increment: 1 } },
+    });
+
+    if (Math.random() < CLEANUP_PROBABILITY) {
+      const cutoff = new Date(Date.now() - CLEANUP_MAX_AGE_MS);
+      void prisma.rateLimitWindow
+        .deleteMany({ where: { windowStart: { lt: cutoff } } })
+        .catch((err) => console.error("Rate limit cleanup failed:", err));
+    }
+
+    if (row.count > config.limit) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((windowStart.getTime() + windowMs - Date.now()) / 1000)
+      );
+      return { allowed: false, retryAfterSeconds };
+    }
+
+    return { allowed: true, retryAfterSeconds: 0 };
+  } catch (err) {
+    console.error(`Rate limit check failed for key "${key}":`, err);
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+}
+
+/**
+ * Client IP for rate-limit keys. On Vercel (and most proxies) the original
+ * client is the first entry of x-forwarded-for.
+ */
+export function getClientIp(req: Request): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+export function rateLimitResponse(retryAfterSeconds: number, message?: string) {
+  return new Response(
+    JSON.stringify({
+      error: message ?? "Too many requests. Please try again later.",
+      code: "RATE_LIMITED",
+    }),
+    {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        "Retry-After": String(retryAfterSeconds),
+      },
+    }
+  );
+}

--- a/prisma/migrations/20260709040000_add_rate_limit_window/migration.sql
+++ b/prisma/migrations/20260709040000_add_rate_limit_window/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "RateLimitWindow" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "windowStart" TIMESTAMP(3) NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RateLimitWindow_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RateLimitWindow_key_windowStart_key" ON "RateLimitWindow"("key", "windowStart");
+
+-- CreateIndex
+CREATE INDEX "RateLimitWindow_windowStart_idx" ON "RateLimitWindow"("windowStart");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -158,6 +158,21 @@ model InventoryItemRecipient {
   @@index([contactId])
 }
 
+// Fixed-window rate limit counters, keyed by "<scope>:<identifier>".
+// DB-backed so limits hold across serverless instances. Old windows are
+// cleaned up opportunistically by lib/rate-limit.ts.
+model RateLimitWindow {
+  id          String   @id @default(cuid())
+  key         String
+  windowStart DateTime
+  count       Int      @default(1)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([key, windowStart])
+  @@index([windowStart])
+}
+
 model StockingRequest {
   id        String        @id @default(cuid())
   itemId    String


### PR DESCRIPTION
Closes #59 — from the production-readiness backlog (#70).

## Design
`lib/rate-limit.ts` implements a **fixed-window limiter backed by Postgres** (new `RateLimitWindow` model + hand-written migration matching the repo's pattern). An in-memory limiter would reset on every serverless cold start, and a hosted limiter (Upstash) would add a vendor — the DB is already shared across instances. One upsert per check; stale windows are swept opportunistically (~1% of calls); **fails open** with a logged error so a limiter problem can't take the product down.

## Budgets
| Endpoint | Limit | Key |
|---|---|---|
| `POST /api/scan/[qrCodeId]` | 30/hr + 120/hr | per IP+item / per item overall |
| Login (Credentials `authorize`) | 5 / 15 min | per IP+email |
| `POST /api/auth/register` | 10/hr | per IP |
| `POST /api/auth/forgot-password` | 5 / 15 min + 5/hr | per IP / per target email |
| `POST /api/auth/reset-password` | 10/hr | per IP (token brute-force) |
| `POST /api/upload` | 30/hr | per user |

Notable details:
- **Scan**: both checks run *before* the item lookup, so floods (including probes of random QR ids) never touch the item table. The scan page's internal server-side fetch now forwards the visitor's `x-forwarded-for` — without this the API would rate-limit the server's own IP. A 429 renders a dedicated "scanned too many times" screen.
- **Login**: a limited attempt throws `CredentialsSignin`, indistinguishable from a wrong password, so attackers learn nothing.
- **Forgot-password per-email cap** returns the normal `{ok: true}` body (suppressing only the send) to preserve the existing anti-enumeration behavior.

## Deploy note
Requires `npm run db:migrate` (already part of the deploy step) to create the `RateLimitWindow` table.

## Verification
`npm run lint` 0 errors · `tsc --noEmit` clean · `env -i npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tTuca5mDZ8i5QMr6LD4Xh

---
_Generated by [Claude Code](https://claude.ai/code/session_016tTuca5mDZ8i5QMr6LD4Xh)_