### PR TITLE
Add /api/health endpoint and structured unhandled-error logging

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -75,6 +75,7 @@
 │   │   ├── requests/
 │   │   │   ├── route.ts          # GET /api/requests
 │   │   │   └── [requestId]/route.ts  # PATCH /api/requests/:id
+│   │   ├── health/route.ts       # GET /api/health — DB round-trip, for uptime monitors (public)
 │   │   ├── push/
 │   │   │   ├── public-key/route.ts   # GET /api/push/public-key
 │   │   │   └── subscription/route.ts # POST / DELETE /api/push/subscription

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("Health check failed:", err);
+    return NextResponse.json({ ok: false }, { status: 503 });
+  }
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,3 +1,5 @@
+import type { Instrumentation } from "next";
+
 export async function register() {
   // Skip during `next build` — env vars are a runtime concern; CI builds
   // intentionally run without any configured environment.
@@ -6,3 +8,36 @@ export async function register() {
   const { validateEnv } = await import("@/lib/env");
   validateEnv();
 }
+
+// Structured log line for every unhandled server error, so log drains and
+// platform dashboards (e.g. Vercel) can filter and alert on them. If a
+// monitoring service (Sentry etc.) is adopted, report from here too.
+export const onRequestError: Instrumentation.onRequestError = async (
+  err,
+  request,
+  context
+) => {
+  const error =
+    err instanceof Error
+      ? {
+          name: err.name,
+          message: err.message,
+          stack: err.stack,
+          digest: (err as { digest?: string }).digest,
+        }
+      : { message: String(err) };
+
+  console.error(
+    JSON.stringify({
+      level: "error",
+      event: "unhandled_request_error",
+      method: request.method,
+      path: request.path,
+      routerKind: context.routerKind,
+      routePath: context.routePath,
+      routeType: context.routeType,
+      error,
+      ts: new Date().toISOString(),
+    })
+  );
+};


### PR DESCRIPTION
Addresses the code-side half of #64 (production-readiness backlog #70).

## `GET /api/health`
Runs `SELECT 1` against Postgres and returns `200 {"ok": true}`, or `503 {"ok": false}` when the DB is unreachable. Marked `force-dynamic` so it's never cached. Point an uptime monitor (Better Uptime, UptimeRobot, Vercel checks) at it after deploy.

## Structured unhandled-error logging
`instrumentation.ts` now exports Next's `onRequestError` hook, emitting one JSON log line per unhandled server error — method, path, router kind, route path/type, error name/message/stack/digest, timestamp. Vercel's log drains and dashboard can filter and alert on `"event":"unhandled_request_error"`.

## What this does *not* include
A hosted error-monitoring service (Sentry etc.) needs an account + DSN — that's an ops decision. When one is adopted, its SDK reports from this same `onRequestError` hook. I'll note this on #64 and leave that box unchecked rather than closing it silently.

## Verification
`npm run lint` 0 errors · `tsc --noEmit` clean · env-free build succeeds, `/api/health` listed as dynamic route

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tTuca5mDZ8i5QMr6LD4Xh

---
_Generated by [Claude Code](https://claude.ai/code/session_016tTuca5mDZ8i5QMr6LD4Xh)_