### PR TITLE
Handle Stripe payment-failure lifecycle

### DIFF
--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -19,6 +19,7 @@ export default async function SettingsPage() {
         tier: true,
         stripeCustomerId: true,
         stripeCurrentPeriodEnd: true,
+        stripeSubscriptionStatus: true,
       },
     }),
     prisma.inventoryItem.count({ where: { userId: session.user.id } }),
@@ -66,6 +67,16 @@ export default async function SettingsPage() {
           <h2 className="font-semibold text-on-surface font-headline">Current Plan</h2>
           <TierBadge tier={tier} />
         </div>
+
+        {user.stripeSubscriptionStatus === "past_due" && (
+          <div className="rounded-lg bg-error-container text-on-error-container text-sm p-3">
+            <p className="font-medium">There&apos;s a problem with your payment method.</p>
+            <p className="mt-1">
+              Your last payment didn&apos;t go through. Update your payment details via
+              &ldquo;Manage subscription&rdquo; below to keep your Pro features.
+            </p>
+          </div>
+        )}
 
         <div className="text-sm text-on-surface-variant space-y-1">
           <p>

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -67,6 +67,7 @@ export async function POST(req: NextRequest) {
             tier,
             stripeCustomerId: session.customer as string,
             stripeSubscriptionId: subscription.id,
+            stripeSubscriptionStatus: subscription.status,
             stripeCurrentPeriodEnd: new Date((subscription.items.data[0]?.current_period_end ?? 0) * 1000),
           },
         });
@@ -99,18 +100,23 @@ export async function POST(req: NextRequest) {
         const productId = typeof itemPrice?.product === "string" ? itemPrice.product : itemPrice?.product?.id;
         const priceId = itemPrice?.id;
 
-        let tier: Tier = "FREE";
-        if (
+        const matchesProPlan =
           (STRIPE_PRODUCTS.PRO && productId === STRIPE_PRODUCTS.PRO) ||
-          (!STRIPE_PRODUCTS.PRO && priceId === STRIPE_PRICES.PRO)
-        ) {
-          tier = "PRO";
-        }
+          (!STRIPE_PRODUCTS.PRO && priceId === STRIPE_PRICES.PRO);
+
+        // PRO is kept through `past_due` so access survives Stripe's dunning
+        // retries; `unpaid`, `canceled`, `paused` etc. downgrade immediately.
+        const statusGrantsAccess = ["active", "trialing", "past_due"].includes(
+          subscription.status
+        );
+
+        const tier: Tier = matchesProPlan && statusGrantsAccess ? "PRO" : "FREE";
 
         await prisma.user.update({
           where: { id: user.id },
           data: {
             tier,
+            stripeSubscriptionStatus: subscription.status,
             stripeCurrentPeriodEnd: new Date((subscription.items.data[0]?.current_period_end ?? 0) * 1000),
           },
         });
@@ -119,7 +125,32 @@ export async function POST(req: NextRequest) {
           eventId: event.id,
           userId: user.id,
           subscriptionId: subscription.id,
+          subscriptionStatus: subscription.status,
           tier,
+        });
+        break;
+      }
+
+      case "invoice.payment_failed": {
+        const invoice = event.data.object as Stripe.Invoice;
+        const customerId =
+          typeof invoice.customer === "string"
+            ? invoice.customer
+            : invoice.customer?.id;
+
+        const user = customerId
+          ? await prisma.user.findFirst({
+              where: { stripeCustomerId: customerId },
+              select: { id: true, email: true },
+            })
+          : null;
+
+        logWebhook("warn", event.type, {
+          eventId: event.id,
+          customerId,
+          userId: user?.id,
+          attemptCount: invoice.attempt_count,
+          nextPaymentAttempt: invoice.next_payment_attempt,
         });
         break;
       }
@@ -131,6 +162,7 @@ export async function POST(req: NextRequest) {
           data: {
             tier: "FREE",
             stripeSubscriptionId: null,
+            stripeSubscriptionStatus: null,
             stripeCurrentPeriodEnd: null,
           },
         });

--- a/prisma/migrations/20260709050000_add_stripe_subscription_status/migration.sql
+++ b/prisma/migrations/20260709050000_add_stripe_subscription_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "stripeSubscriptionStatus" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model User {
   stripeCustomerId       String?         @unique
   stripeSubscriptionId   String?         @unique
   stripeCurrentPeriodEnd DateTime?
+  stripeSubscriptionStatus String?
   emailVerifiedAt        DateTime?
   passwordResetToken     String?
   passwordResetExpiry    DateTime?


### PR DESCRIPTION
Closes #65 — from the production-readiness backlog (#70).

## Problem
`customer.subscription.updated` mapped tier purely from the product/price and ignored `subscription.status` — a subscription in `past_due` or `unpaid` kept the user on PRO indefinitely.

## Changes
- **Status-gated tier**: PRO requires the Pro plan **and** status in `active` / `trialing` / `past_due`. Anything else (`unpaid`, `canceled`, `paused`, `incomplete_expired`, …) downgrades to FREE on the spot.
- **Grace-period policy (flagging for your review)**: I kept PRO through `past_due` so access survives Stripe's Smart-Retries dunning window (typically 1–3 weeks, per your Stripe dashboard settings), downgrading only when Stripe gives up and the status moves to `unpaid`/`canceled`. This matches common SaaS practice. If you'd rather cut access on the first failed payment, remove `"past_due"` from `statusGrantsAccess` in the webhook — one-line change.
- **Status persisted**: new `User.stripeSubscriptionStatus` column (+ migration), written on checkout completion and subscription updates, cleared on deletion.
- **`invoice.payment_failed`** events are now logged with attempt count and next retry time.
- **User-facing messaging**: the Settings → Current Plan section shows a payment-problem banner when the subscription is `past_due`, directing the user to the existing "Manage subscription" portal button (Stripe's dunning emails remain the primary nudge).

## Deploy note
Requires `npm run db:migrate`. Also ensure the Stripe webhook endpoint subscribes to `invoice.payment_failed` in addition to the existing events.

## Verification
`npm run lint` 0 errors · `tsc --noEmit` clean · env-free build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tTuca5mDZ8i5QMr6LD4Xh

---
_Generated by [Claude Code](https://claude.ai/code/session_016tTuca5mDZ8i5QMr6LD4Xh)_